### PR TITLE
feat: Channels tab for Meta Messenger integration

### DIFF
--- a/src/components/settings/ChannelsSettings.tsx
+++ b/src/components/settings/ChannelsSettings.tsx
@@ -1,0 +1,523 @@
+/**
+ * ChannelsSettings Component
+ * Manages Meta Messenger and Instagram DM channel integrations.
+ *
+ * OAuth flow uses a popup window so the user never leaves the config builder.
+ * Toggle and disconnect actions POST to the backend (DynamoDB), not to S3.
+ * The S3 config only ever holds display metadata (page_name, enabled, connected_at).
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { CheckCircle2, ExternalLink, Facebook, Instagram, Loader2, XCircle } from 'lucide-react';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui';
+import { useConfigStore } from '@/store';
+import { useAuth } from '@/context/AuthContext';
+import type { ChannelConnection, ChannelsConfig } from '@/types/config';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://api.yourapi.com/api';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StatusBadge — inline connection status chip
+// ---------------------------------------------------------------------------
+
+interface StatusBadgeProps {
+  connected: boolean;
+}
+
+const StatusBadge: React.FC<StatusBadgeProps> = ({ connected }) =>
+  connected ? (
+    <span
+      role="status"
+      aria-label="Connected"
+      className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300"
+    >
+      <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+      Connected
+    </span>
+  ) : (
+    <span
+      role="status"
+      aria-label="Not connected"
+      className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+    >
+      <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
+      Not connected
+    </span>
+  );
+
+// ---------------------------------------------------------------------------
+// ToggleSwitch — accessible on/off toggle
+// ---------------------------------------------------------------------------
+
+interface ToggleSwitchProps {
+  id: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+}
+
+const ToggleSwitch: React.FC<ToggleSwitchProps> = ({ id, checked, disabled, onChange, label }) => (
+  <label htmlFor={id} className="flex cursor-pointer items-center gap-2 select-none">
+    <button
+      id={id}
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={[
+        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+        'disabled:pointer-events-none disabled:opacity-50',
+        checked
+          ? 'bg-primary'
+          : 'bg-gray-200 dark:bg-gray-700',
+      ].join(' ')}
+    >
+      <span
+        aria-hidden="true"
+        className={[
+          'pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform',
+          checked ? 'translate-x-5' : 'translate-x-0',
+        ].join(' ')}
+      />
+    </button>
+    <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+  </label>
+);
+
+// ---------------------------------------------------------------------------
+// ConnectedCard — shows page info, enable toggle, disconnect button
+// ---------------------------------------------------------------------------
+
+interface ConnectedCardProps {
+  pageName: string;
+  connectedAt: string;
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  onDisconnect: () => void;
+  toggleLoading: boolean;
+  disconnectLoading: boolean;
+  toggleId: string;
+}
+
+const ConnectedCard: React.FC<ConnectedCardProps> = ({
+  pageName,
+  connectedAt,
+  enabled,
+  onToggle,
+  onDisconnect,
+  toggleLoading,
+  disconnectLoading,
+  toggleId,
+}) => (
+  <div className="space-y-4">
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+      <div>
+        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{pageName}</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Connected {formatDate(connectedAt)}
+        </p>
+      </div>
+      <StatusBadge connected />
+    </div>
+
+    <div className="flex flex-wrap items-center justify-between gap-4">
+      {toggleLoading ? (
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          Updating…
+        </div>
+      ) : (
+        <ToggleSwitch
+          id={toggleId}
+          checked={enabled}
+          onChange={onToggle}
+          label={enabled ? 'Channel enabled' : 'Channel disabled'}
+        />
+      )}
+
+      <Button
+        variant="danger"
+        size="sm"
+        loading={disconnectLoading}
+        onClick={onDisconnect}
+        aria-label="Disconnect this channel"
+      >
+        Disconnect
+      </Button>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// ChannelsSettings (main export)
+// ---------------------------------------------------------------------------
+
+/**
+ * ChannelsSettings Component
+ *
+ * Manages Meta Messenger and Instagram DM channel integrations:
+ * - Facebook Messenger: OAuth popup connect, enable/disable toggle, disconnect
+ * - Instagram DMs: Coming Soon placeholder
+ * - Channel Status: Summary of active connections
+ *
+ * @example
+ * ```tsx
+ * <ChannelsSettings />
+ * ```
+ */
+export const ChannelsSettings: React.FC = () => {
+  const tenantId = useConfigStore((state) => state.config.tenantId);
+  const baseConfig = useConfigStore((state) => state.config.baseConfig);
+  const { getToken } = useAuth();
+
+  const messengerConfig = baseConfig?.channels?.messenger;
+
+  // Loading states
+  const [connectLoading, setConnectLoading] = useState(false);
+  const [toggleLoading, setToggleLoading] = useState(false);
+  const [disconnectLoading, setDisconnectLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Ref to keep track of the OAuth popup window
+  const popupRef = useRef<Window | null>(null);
+
+  // -------------------------------------------------------------------------
+  // Optimistically update channels config in the Zustand store
+  // -------------------------------------------------------------------------
+
+  const setChannelsConfig = useCallback((updater: (prev: ChannelsConfig | undefined) => ChannelsConfig | undefined) => {
+    useConfigStore.setState((state) => {
+      if (state.config.baseConfig) {
+        state.config.baseConfig.channels = updater(state.config.baseConfig.channels);
+        state.config.isDirty = true;
+      }
+    });
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // OAuth popup flow
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type !== 'META_OAUTH_SUCCESS') return;
+      const payload = event.data?.payload as ChannelConnection | undefined;
+      if (!payload) return;
+
+      // Update local store with the page data returned from OAuth
+      setChannelsConfig((prev) => ({
+        ...prev,
+        messenger: payload,
+      }));
+      setConnectLoading(false);
+      popupRef.current?.close();
+    };
+
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [setChannelsConfig]);
+
+  const handleConnect = useCallback(async () => {
+    if (!tenantId) return;
+    setError(null);
+    setConnectLoading(true);
+
+    try {
+      const token = await getToken();
+      const res = await fetch(
+        `${API_BASE_URL}/meta/oauth/url?tenant_id=${encodeURIComponent(tenantId)}`,
+        {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        }
+      );
+
+      if (!res.ok) {
+        throw new Error(`Failed to get OAuth URL (${res.status})`);
+      }
+
+      const { url } = await res.json() as { url: string };
+
+      // Open OAuth in a centred popup
+      const width = 600;
+      const height = 700;
+      const left = Math.round(window.screenX + (window.outerWidth - width) / 2);
+      const top = Math.round(window.screenY + (window.outerHeight - height) / 2);
+      popupRef.current = window.open(
+        url,
+        'meta_oauth',
+        `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no`
+      );
+
+      if (!popupRef.current) {
+        throw new Error('Popup was blocked. Please allow popups for this site.');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to initiate connection.');
+      setConnectLoading(false);
+    }
+  }, [tenantId, getToken]);
+
+  // -------------------------------------------------------------------------
+  // Toggle enabled/disabled
+  // -------------------------------------------------------------------------
+
+  const handleToggle = useCallback(
+    async (enabled: boolean) => {
+      if (!tenantId) return;
+      setError(null);
+      setToggleLoading(true);
+
+      // Optimistic update
+      setChannelsConfig((prev) => ({
+        ...prev,
+        messenger: prev?.messenger ? { ...prev.messenger, enabled } : undefined,
+      }));
+
+      try {
+        const token = await getToken();
+        const res = await fetch(`${API_BASE_URL}/meta/channels/${encodeURIComponent(tenantId)}/toggle`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ channel: 'messenger', enabled }),
+        });
+
+        if (!res.ok) {
+          // Roll back on failure
+          setChannelsConfig((prev) => ({
+            ...prev,
+            messenger: prev?.messenger ? { ...prev.messenger, enabled: !enabled } : undefined,
+          }));
+          throw new Error(`Toggle failed (${res.status})`);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to update channel status.');
+      } finally {
+        setToggleLoading(false);
+      }
+    },
+    [tenantId, getToken, setChannelsConfig]
+  );
+
+  // -------------------------------------------------------------------------
+  // Disconnect
+  // -------------------------------------------------------------------------
+
+  const handleDisconnect = useCallback(async () => {
+    if (!tenantId) return;
+    const confirmed = window.confirm(
+      'Are you sure you want to disconnect this Facebook Page? Messages from Messenger will no longer be routed to Picasso.'
+    );
+    if (!confirmed) return;
+
+    setError(null);
+    setDisconnectLoading(true);
+
+    try {
+      const token = await getToken();
+      const res = await fetch(
+        `${API_BASE_URL}/meta/channels/${encodeURIComponent(tenantId)}/disconnect`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ channel: 'messenger' }),
+        }
+      );
+
+      if (!res.ok) {
+        throw new Error(`Disconnect failed (${res.status})`);
+      }
+
+      // Remove messenger from local store
+      setChannelsConfig((prev) => {
+        if (!prev) return prev;
+        const { messenger: _removed, ...rest } = prev;
+        return rest;
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disconnect channel.');
+    } finally {
+      setDisconnectLoading(false);
+    }
+  }, [tenantId, getToken, setChannelsConfig]);
+
+  // -------------------------------------------------------------------------
+  // Derived state
+  // -------------------------------------------------------------------------
+
+  const messengerConnected = Boolean(messengerConfig);
+  const instagramConnected = Boolean(baseConfig?.channels?.instagram);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className="space-y-6">
+      {/* Global error banner */}
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300"
+        >
+          <XCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+          <button
+            className="ml-auto shrink-0 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+            onClick={() => setError(null)}
+            aria-label="Dismiss error"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Card 1: Facebook Messenger                                          */}
+      {/* ------------------------------------------------------------------ */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Facebook className="h-5 w-5 text-[#1877F2]" aria-hidden="true" />
+            Facebook Messenger
+          </CardTitle>
+          <CardDescription>
+            Route Messenger conversations from your Facebook Page directly into Picasso.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {messengerConnected && messengerConfig ? (
+            <ConnectedCard
+              pageName={messengerConfig.page_name}
+              connectedAt={messengerConfig.connected_at}
+              enabled={messengerConfig.enabled}
+              onToggle={handleToggle}
+              onDisconnect={handleDisconnect}
+              toggleLoading={toggleLoading}
+              disconnectLoading={disconnectLoading}
+              toggleId="messenger-enabled-toggle"
+            />
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Connect a Facebook Page to start receiving Messenger conversations in Picasso.
+              </p>
+              <Button
+                variant="primary"
+                size="sm"
+                loading={connectLoading}
+                onClick={handleConnect}
+                disabled={!tenantId}
+                aria-label="Connect a Facebook Page via Meta OAuth"
+                leftIcon={<ExternalLink className="h-4 w-4" aria-hidden="true" />}
+              >
+                Connect Facebook Page
+              </Button>
+              {!tenantId && (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  Select a tenant first to connect a channel.
+                </p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Card 2: Instagram DMs                                               */}
+      {/* ------------------------------------------------------------------ */}
+      <Card className="opacity-75">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Instagram className="h-5 w-5 text-[#E1306C]" aria-hidden="true" />
+            Instagram DMs
+            <span className="ml-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+              Coming Soon
+            </span>
+          </CardTitle>
+          <CardDescription>
+            Route Instagram Direct Messages into Picasso (requires a connected Facebook Page).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled
+            aria-label="Instagram DMs — coming soon"
+            aria-disabled="true"
+          >
+            Connect Instagram Account
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Card 3: Channel Status                                              */}
+      {/* ------------------------------------------------------------------ */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Channel Status</CardTitle>
+          <CardDescription>Connection health summary</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+              <dt className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+                <Facebook className="h-4 w-4 text-[#1877F2]" aria-hidden="true" />
+                Messenger
+              </dt>
+              <dd>
+                <StatusBadge connected={messengerConnected} />
+              </dd>
+            </div>
+            <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+              <dt className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+                <Instagram className="h-4 w-4 text-[#E1306C]" aria-hidden="true" />
+                Instagram DMs
+              </dt>
+              <dd>
+                <StatusBadge connected={instagramConnected} />
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/settings/__tests__/ChannelsSettings.test.tsx
+++ b/src/components/settings/__tests__/ChannelsSettings.test.tsx
@@ -1,0 +1,517 @@
+/**
+ * ChannelsSettings Component Tests
+ *
+ * Covers:
+ * - Disconnected state (Connect button visible)
+ * - Connected state (page info, toggle, disconnect)
+ * - OAuth popup launch and postMessage handling
+ * - Toggle optimistic update and rollback on failure
+ * - Disconnect confirmation and API call
+ * - Accessibility: ARIA roles, keyboard navigation, focus management
+ * - Channel Status summary card
+ * - No tenant selected guard
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ---------------------------------------------------------------------------
+// Mock: useConfigStore
+// ---------------------------------------------------------------------------
+
+const mockSetState = vi.fn();
+const mockBaseConfig: Record<string, unknown> = {};
+let mockTenantId: string | null = 'TENANT123';
+
+vi.mock('@/store', () => ({
+  useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      config: {
+        tenantId: mockTenantId,
+        baseConfig: mockBaseConfig,
+        isDirty: false,
+      },
+    })
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: useAuth
+// ---------------------------------------------------------------------------
+
+const mockGetToken = vi.fn().mockResolvedValue('mock-jwt-token');
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ getToken: mockGetToken }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: global fetch
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// ---------------------------------------------------------------------------
+// Mock: window.open (popup)
+// ---------------------------------------------------------------------------
+
+const mockPopup = { close: vi.fn() };
+const mockWindowOpen = vi.fn().mockReturnValue(mockPopup);
+Object.defineProperty(window, 'open', { writable: true, value: mockWindowOpen });
+
+// ---------------------------------------------------------------------------
+// Mock: window.confirm
+// ---------------------------------------------------------------------------
+
+vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Patch useConfigStore.setState so store mutations are captured
+import { useConfigStore } from '@/store';
+
+function setupStore(channels?: Record<string, unknown>) {
+  // Reset baseConfig for each test
+  Object.keys(mockBaseConfig).forEach((k) => delete (mockBaseConfig as Record<string, unknown>)[k]);
+  if (channels) {
+    (mockBaseConfig as Record<string, unknown>).channels = channels;
+  }
+  // Wire setState
+  (useConfigStore as unknown as { setState: typeof mockSetState }).setState = mockSetState;
+}
+
+// ---------------------------------------------------------------------------
+// Import component under test (after mocks are declared)
+// ---------------------------------------------------------------------------
+
+import { ChannelsSettings } from '../ChannelsSettings';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChannelsSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTenantId = 'TENANT123';
+    setupStore();
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    mockWindowOpen.mockReturnValue(mockPopup);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Rendering — disconnected state
+  // -------------------------------------------------------------------------
+
+  describe('disconnected state', () => {
+    it('renders the Facebook Messenger card heading', () => {
+      render(<ChannelsSettings />);
+      expect(screen.getByText('Facebook Messenger')).toBeInTheDocument();
+    });
+
+    it('renders a "Connect Facebook Page" button when not connected', () => {
+      render(<ChannelsSettings />);
+      expect(
+        screen.getByRole('button', { name: /connect facebook page/i })
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT render toggle or disconnect when not connected', () => {
+      render(<ChannelsSettings />);
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /disconnect/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows Instagram card as Coming Soon', () => {
+      render(<ChannelsSettings />);
+      expect(screen.getByText('Instagram DMs')).toBeInTheDocument();
+      expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+    });
+
+    it('disables Connect button when no tenant is selected', () => {
+      mockTenantId = null;
+      render(<ChannelsSettings />);
+      expect(
+        screen.getByRole('button', { name: /connect facebook page/i })
+      ).toBeDisabled();
+    });
+
+    it('shows a "select a tenant first" hint when tenant is null', () => {
+      mockTenantId = null;
+      render(<ChannelsSettings />);
+      expect(
+        screen.getByText(/select a tenant first/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Channel Status card
+  // -------------------------------------------------------------------------
+
+  describe('Channel Status card', () => {
+    it('shows Messenger as "Not connected" when no config', () => {
+      render(<ChannelsSettings />);
+      const statusCard = screen.getByText('Channel Status').closest('div')!;
+      const messengerRow = within(statusCard).getByText('Messenger').closest('div')!;
+      expect(within(messengerRow).getByRole('status', { name: /not connected/i })).toBeInTheDocument();
+    });
+
+    it('shows Messenger as "Connected" when config present', () => {
+      setupStore({
+        messenger: {
+          page_id: '111',
+          page_name: 'My Page',
+          enabled: true,
+          connected_at: '2024-01-15T10:00:00Z',
+          connected_by: 'admin@example.com',
+        },
+      });
+      render(<ChannelsSettings />);
+      // The connected badge in the top card
+      const badges = screen.getAllByRole('status', { name: /connected/i });
+      expect(badges.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rendering — connected state
+  // -------------------------------------------------------------------------
+
+  describe('connected state', () => {
+    beforeEach(() => {
+      setupStore({
+        messenger: {
+          page_id: '111',
+          page_name: 'Acme Recruiting Page',
+          enabled: true,
+          connected_at: '2024-06-01T08:00:00Z',
+          connected_by: 'admin@example.com',
+        },
+      });
+    });
+
+    it('renders the page name', () => {
+      render(<ChannelsSettings />);
+      expect(screen.getByText('Acme Recruiting Page')).toBeInTheDocument();
+    });
+
+    it('renders an enabled toggle switch', () => {
+      render(<ChannelsSettings />);
+      const toggle = screen.getByRole('switch', { name: /channel enabled/i });
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('renders a Disconnect button', () => {
+      render(<ChannelsSettings />);
+      expect(
+        screen.getByRole('button', { name: /disconnect this channel/i })
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT render "Connect Facebook Page" when already connected', () => {
+      render(<ChannelsSettings />);
+      expect(
+        screen.queryByRole('button', { name: /connect facebook page/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // OAuth popup flow
+  // -------------------------------------------------------------------------
+
+  describe('OAuth popup', () => {
+    it('fetches OAuth URL and opens a popup on connect click', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ url: 'https://facebook.com/oauth/test' }),
+      });
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('button', { name: /connect facebook page/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/meta/oauth/url?tenant_id=TENANT123'),
+          expect.any(Object)
+        );
+      });
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        'https://facebook.com/oauth/test',
+        'meta_oauth',
+        expect.stringContaining('width=600')
+      );
+    });
+
+    it('shows an error when the OAuth URL fetch fails', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('button', { name: /connect facebook page/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+    });
+
+    it('updates store state when META_OAUTH_SUCCESS postMessage is received', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ url: 'https://facebook.com/oauth/test' }),
+      });
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('button', { name: /connect facebook page/i }));
+
+      // Simulate the OAuth callback postMessage
+      const payload = {
+        page_id: '222',
+        page_name: 'New Page',
+        enabled: true,
+        connected_at: '2024-07-01T00:00:00Z',
+        connected_by: 'user@example.com',
+      };
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { type: 'META_OAUTH_SUCCESS', payload } })
+      );
+
+      await waitFor(() => {
+        expect(mockSetState).toHaveBeenCalled();
+      });
+    });
+
+    it('ignores postMessage events with wrong type', async () => {
+      render(<ChannelsSettings />);
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { type: 'SOME_OTHER_EVENT', payload: {} } })
+      );
+      // setState should not be called for unrelated messages
+      expect(mockSetState).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Toggle
+  // -------------------------------------------------------------------------
+
+  describe('enable/disable toggle', () => {
+    beforeEach(() => {
+      setupStore({
+        messenger: {
+          page_id: '111',
+          page_name: 'Acme Page',
+          enabled: true,
+          connected_at: '2024-06-01T08:00:00Z',
+          connected_by: 'admin@example.com',
+        },
+      });
+    });
+
+    it('calls the toggle API when the switch is clicked', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+      render(<ChannelsSettings />);
+      const toggle = screen.getByRole('switch');
+      await user.click(toggle);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/meta/channels/TENANT123/toggle'),
+          expect.objectContaining({ method: 'POST' })
+        );
+      });
+    });
+
+    it('makes an optimistic store update before the API resolves', async () => {
+      const user = userEvent.setup();
+      // Never resolve so we can inspect the optimistic call
+      mockFetch.mockImplementationOnce(() => new Promise(() => {}));
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('switch'));
+
+      expect(mockSetState).toHaveBeenCalled();
+    });
+
+    it('shows an error and rolls back on toggle API failure', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('switch'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+      // Rollback means setState was called at least twice
+      expect(mockSetState.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Disconnect
+  // -------------------------------------------------------------------------
+
+  describe('disconnect flow', () => {
+    beforeEach(() => {
+      setupStore({
+        messenger: {
+          page_id: '111',
+          page_name: 'Acme Page',
+          enabled: true,
+          connected_at: '2024-06-01T08:00:00Z',
+          connected_by: 'admin@example.com',
+        },
+      });
+    });
+
+    it('calls the disconnect API after confirmation', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('button', { name: /disconnect this channel/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/meta/channels/TENANT123/disconnect'),
+          expect.objectContaining({ method: 'POST' })
+        );
+      });
+    });
+
+    it('does NOT call the API when the user cancels the confirmation', async () => {
+      vi.stubGlobal('confirm', vi.fn().mockReturnValue(false));
+      const user = userEvent.setup();
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('button', { name: /disconnect this channel/i }));
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('shows an error when disconnect fails', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('button', { name: /disconnect this channel/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error dismissal
+  // -------------------------------------------------------------------------
+
+  describe('error banner', () => {
+    it('can be dismissed by clicking the close button', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      render(<ChannelsSettings />);
+      await user.click(screen.getByRole('button', { name: /connect facebook page/i }));
+
+      await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+      await user.click(screen.getByRole('button', { name: /dismiss error/i }));
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+
+  describe('accessibility', () => {
+    it('toggle has correct ARIA switch role and aria-checked attribute', () => {
+      setupStore({
+        messenger: {
+          page_id: '111',
+          page_name: 'Page',
+          enabled: false,
+          connected_at: '2024-01-01T00:00:00Z',
+          connected_by: 'u@example.com',
+        },
+      });
+      render(<ChannelsSettings />);
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('toggle receives focus and responds to Space key', async () => {
+      setupStore({
+        messenger: {
+          page_id: '111',
+          page_name: 'Page',
+          enabled: true,
+          connected_at: '2024-01-01T00:00:00Z',
+          connected_by: 'u@example.com',
+        },
+      });
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      render(<ChannelsSettings />);
+      const toggle = screen.getByRole('switch');
+      toggle.focus();
+      await user.keyboard(' ');
+
+      expect(mockSetState).toHaveBeenCalled();
+    });
+
+    it('status badges have descriptive aria-labels', () => {
+      render(<ChannelsSettings />);
+      expect(screen.getAllByRole('status', { name: /not connected/i }).length).toBeGreaterThan(0);
+    });
+
+    it('icons are hidden from assistive technology with aria-hidden', () => {
+      render(<ChannelsSettings />);
+      // All decorative SVG icons should be aria-hidden
+      const icons = document.querySelectorAll('svg[aria-hidden="true"]');
+      expect(icons.length).toBeGreaterThan(0);
+    });
+
+    it('Instagram Coming Soon button is aria-disabled', () => {
+      render(<ChannelsSettings />);
+      const instagramBtn = screen.getByRole('button', { name: /instagram.*coming soon/i });
+      expect(instagramBtn).toBeDisabled();
+    });
+
+    it('Connect button is keyboard accessible via Enter key', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ url: 'https://facebook.com/oauth/test' }),
+      });
+
+      render(<ChannelsSettings />);
+      const connectBtn = screen.getByRole('button', { name: /connect facebook page/i });
+      connectBtn.focus();
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -13,3 +13,4 @@ export { WidgetBehaviorSettings } from './WidgetBehaviorSettings';
 export { AWSSettings } from './AWSSettings';
 export { FeatureFlagsSettings } from './FeatureFlagsSettings';
 export { NotificationSettings } from './NotificationSettings';
+export { ChannelsSettings } from './ChannelsSettings';

--- a/src/lib/schemas/tenant.schema.ts
+++ b/src/lib/schemas/tenant.schema.ts
@@ -195,6 +195,33 @@ export const cardInventorySchema = z.object({
 });
 
 // ============================================================================
+// CHANNELS SCHEMA (Facebook Messenger / Instagram DMs)
+// ============================================================================
+
+export const channelConnectionSchema = z.object({
+  page_id: z.string().min(1, 'Page ID is required'),
+  page_name: z.string().min(1, 'Page name is required'),
+  enabled: z.boolean(),
+  connected_at: z.string(),
+  connected_by: z.string(),
+});
+
+export const instagramChannelConnectionSchema = z.object({
+  account_id: z.string().min(1, 'Account ID is required'),
+  account_name: z.string().min(1, 'Account name is required'),
+  enabled: z.boolean(),
+  connected_at: z.string(),
+  connected_by: z.string(),
+});
+
+export const channelsConfigSchema = z
+  .object({
+    messenger: channelConnectionSchema.optional(),
+    instagram: instagramChannelConnectionSchema.optional(),
+  })
+  .optional();
+
+// ============================================================================
 // FULL TENANT CONFIG SCHEMA
 // ============================================================================
 
@@ -228,6 +255,9 @@ export const tenantConfigSchema = z.object({
   widget_behavior: widgetBehaviorConfigSchema.optional(),
   cta_settings: ctaSettingsSchema.optional(),
   aws: awsConfigSchema,
+
+  // Channel integrations
+  channels: channelsConfigSchema,
 
 }).superRefine((data, ctx) => {
   // Validate feature dependencies
@@ -325,3 +355,6 @@ export type ProgramCard = z.infer<typeof programCardSchema>;
 export type ReadinessThresholds = z.infer<typeof readinessThresholdsSchema>;
 export type CardInventory = z.infer<typeof cardInventorySchema>;
 export type TenantConfig = z.infer<typeof tenantConfigSchema>;
+export type ChannelConnection = z.infer<typeof channelConnectionSchema>;
+export type InstagramChannelConnection = z.infer<typeof instagramChannelConnectionSchema>;
+export type ChannelsConfig = z.infer<typeof channelsConfigSchema>;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -20,6 +20,7 @@ import {
   AWSSettings,
   FeatureFlagsSettings,
   NotificationSettings,
+  ChannelsSettings,
 } from '@/components/settings';
 import { EmbedCodeSettings } from '@/components/settings/EmbedCodeSettings';
 
@@ -172,6 +173,7 @@ export const SettingsPage: React.FC = () => {
               <TabsTrigger value="branding">Branding</TabsTrigger>
               <TabsTrigger value="features">Features</TabsTrigger>
               <TabsTrigger value="ai-aws">AI & AWS</TabsTrigger>
+              <TabsTrigger value="channels">Channels</TabsTrigger>
             </TabsList>
 
             {/* General Tab */}
@@ -199,6 +201,11 @@ export const SettingsPage: React.FC = () => {
               <BedrockInstructionsSettings />
               <AWSSettings />
               <FeatureFlagsSettings />
+            </TabsContent>
+
+            {/* Channels Tab */}
+            <TabsContent value="channels" className="space-y-6 mt-6">
+              <ChannelsSettings />
             </TabsContent>
           </Tabs>
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -587,6 +587,33 @@ export interface NotificationSettings {
 }
 
 // ============================================================================
+// CHANNELS CONFIG (Facebook Messenger / Instagram DMs)
+// ============================================================================
+
+export type ChannelType = 'messenger' | 'instagram';
+
+export interface ChannelConnection {
+  page_id: string;
+  page_name: string;
+  enabled: boolean;
+  connected_at: string;
+  connected_by: string;
+}
+
+export interface InstagramChannelConnection {
+  account_id: string;
+  account_name: string;
+  enabled: boolean;
+  connected_at: string;
+  connected_by: string;
+}
+
+export interface ChannelsConfig {
+  messenger?: ChannelConnection;
+  instagram?: InstagramChannelConnection;
+}
+
+// ============================================================================
 // FULL TENANT CONFIG
 // ============================================================================
 
@@ -640,6 +667,9 @@ export interface TenantConfig {
 
   // Notification delivery configuration
   notification_settings?: NotificationSettings;
+
+  // Channel integrations (Facebook Messenger, Instagram DMs)
+  channels?: ChannelsConfig;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds a "Channels" tab to the Config Builder Settings page for connecting Facebook Pages and Instagram accounts to Picasso tenants.

- **TenantConfig types** — `ChannelType`, `ChannelConnection`, `InstagramChannelConnection`, `ChannelsConfig` added to `config.ts`
- **Zod schema** — `channelsConfigSchema` with validation for messenger and instagram channel connections
- **ChannelsSettings component** — OAuth popup flow for connecting Facebook Pages, enabled toggle, disconnect with confirmation, Instagram "Coming Soon" placeholder, channel status summary
- **SettingsPage** — New "Channels" tab added to the tabbed settings UI

### Design notes
- No tokens in the frontend — S3 config stores display metadata only (page_name, enabled, connected_at)
- OAuth flow opens Meta dialog in a popup (`window.open`), receives result via `postMessage`
- Toggle and disconnect make API calls to the backend (modify DynamoDB, not S3 config)
- Accessible: `role="switch"` toggles, `role="alert"` error banner, `aria-disabled` on Coming Soon

### Companion PR
- Lambda backend: longhornrumble/lambda#2

## Test plan

- [x] 28 component tests (vitest + @testing-library/react)
- [ ] Visual: dev server → Settings → Channels tab renders correctly
- [ ] OAuth flow: Connect button opens Meta popup (requires backend deployed)
- [ ] Toggle/disconnect: API calls succeed with backend running

🤖 Generated with [Claude Code](https://claude.com/claude-code)