### PR TITLE
fix: align validation unit tests with current rule set

### DIFF
--- a/src/lib/utils/__tests__/type-guards.test.ts
+++ b/src/lib/utils/__tests__/type-guards.test.ts
@@ -434,7 +434,11 @@ describe('Type Guards', () => {
         expect(isValidBranch(branch)).toBe(true);
       });
 
-      it('should reject branches without keywords', () => {
+      // Note: `isValidBranch` validates structural shape only. After V4
+      // routing changes, empty `detection_keywords` no longer makes a branch
+      // invalid — the guard accepts it as long as `available_ctas` is
+      // well-formed.
+      it('should accept branches with empty keywords (keywords no longer required)', () => {
         const branch = {
           detection_keywords: [],
           available_ctas: {
@@ -443,7 +447,7 @@ describe('Type Guards', () => {
           },
         };
 
-        expect(isValidBranch(branch)).toBe(false);
+        expect(isValidBranch(branch)).toBe(true);
       });
 
       it('should reject invalid structures', () => {

--- a/src/lib/validation/__tests__/branchValidation.test.ts
+++ b/src/lib/validation/__tests__/branchValidation.test.ts
@@ -1,6 +1,13 @@
 /**
  * Branch Validation Tests
  * Comprehensive tests for branch validation rules
+ *
+ * Note: This suite was aligned with the current branchValidation.ts after the
+ * V4 routing changes removed several rules (keyword-required, question-word
+ * warnings, cross-branch overlap detection, and priority suggestions). The
+ * current validator only checks CTA references and the max-CTAs-per-response
+ * cap. Tests for removed rules have been updated to assert the new behavior
+ * rather than resurrect deleted logic.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -19,97 +26,18 @@ describe('Branch Validation', () => {
   const allCTAs = { 'test-cta': mockCTA };
 
   describe('keyword validation', () => {
-    it('should require at least one keyword', () => {
+    it('should allow branches without keywords (V4 routing no longer requires them)', () => {
       const branch: ConversationBranch = {
-        detection_keywords: [], // No keywords
+        detection_keywords: [],
         available_ctas: {
           primary: 'test-cta',
           secondary: [],
         },
       };
 
-      const result = validateBranch(branch, 'test-branch', allCTAs, {});
-      expect(result.valid).toBe(false);
-      expect(result.errors.some((e) => e.message.includes('keyword'))).toBe(true);
-    });
-
-    it('should warn about question words in keywords', () => {
-      const questionKeywords = [
-        'how do I apply',
-        'what is this program',
-        'when can I apply',
-        'where do I go',
-        'why should I apply',
-      ];
-
-      questionKeywords.forEach((keyword) => {
-        const branch: ConversationBranch = {
-          detection_keywords: [keyword],
-          available_ctas: {
-            primary: 'test-cta',
-            secondary: [],
-          },
-        };
-
-        const result = validateBranch(branch, 'test-branch', allCTAs, {});
-        expect(result.valid).toBe(true);
-        expect(result.warnings.some((w) => w.message.includes('question words'))).toBe(true);
-      });
-    });
-
-    it('should warn about keyword overlap with other branches', () => {
-      const branch1: ConversationBranch = {
-        detection_keywords: ['housing', 'rental', 'assistance', 'affordable'],
-        available_ctas: {
-          primary: 'test-cta',
-          secondary: [],
-        },
-      };
-
-      const branch2: ConversationBranch = {
-        detection_keywords: ['housing', 'rental', 'application'],
-        available_ctas: {
-          primary: 'test-cta',
-          secondary: [],
-        },
-      };
-
-      const allBranches = {
-        'branch-1': branch1,
-        'branch-2': branch2,
-      };
-
-      const result = validateBranch(branch2, 'branch-2', allCTAs, allBranches);
+      const result = validateBranch(branch, 'test-branch', allCTAs);
       expect(result.valid).toBe(true);
-      expect(result.warnings.some((w) => w.message.includes('overlap'))).toBe(true);
-    });
-
-    it('should not warn about minor keyword overlap', () => {
-      const branch1: ConversationBranch = {
-        detection_keywords: ['housing', 'rental', 'assistance', 'affordable'],
-        available_ctas: {
-          primary: 'test-cta',
-          secondary: [],
-        },
-      };
-
-      const branch2: ConversationBranch = {
-        detection_keywords: ['medical', 'healthcare', 'clinic', 'doctor'],
-        available_ctas: {
-          primary: 'test-cta',
-          secondary: [],
-        },
-      };
-
-      const allBranches = {
-        'branch-1': branch1,
-        'branch-2': branch2,
-      };
-
-      const result = validateBranch(branch2, 'branch-2', allCTAs, allBranches);
-      expect(result.valid).toBe(true);
-      const overlapWarnings = result.warnings.filter((w) => w.message.includes('overlap'));
-      expect(overlapWarnings).toHaveLength(0);
+      expect(result.errors.some((e) => e.message.toLowerCase().includes('keyword'))).toBe(false);
     });
   });
 
@@ -123,7 +51,7 @@ describe('Branch Validation', () => {
         },
       };
 
-      const result = validateBranch(branch, 'test-branch', allCTAs, {});
+      const result = validateBranch(branch, 'test-branch', allCTAs);
       expect(result.valid).toBe(false);
       expect(result.errors.some((e) => e.message.includes('primary CTA'))).toBe(true);
     });
@@ -137,7 +65,7 @@ describe('Branch Validation', () => {
         },
       };
 
-      const result = validateBranch(branch, 'test-branch', allCTAs, {});
+      const result = validateBranch(branch, 'test-branch', allCTAs);
       expect(result.valid).toBe(false);
       expect(result.errors.some((e) => e.message.includes('does not exist'))).toBe(true);
     });
@@ -151,9 +79,10 @@ describe('Branch Validation', () => {
         },
       };
 
-      const result = validateBranch(branch, 'test-branch', allCTAs, {});
+      const result = validateBranch(branch, 'test-branch', allCTAs);
       expect(result.valid).toBe(false);
-      expect(result.errors.some((e) => e.message.includes('secondary'))).toBe(true);
+      // Current message is "Secondary CTA <n> \"<id>\" does not exist" — match case-insensitively.
+      expect(result.errors.some((e) => e.message.toLowerCase().includes('secondary'))).toBe(true);
     });
 
     it('should validate successfully with valid CTAs', () => {
@@ -176,14 +105,13 @@ describe('Branch Validation', () => {
       const result = validateBranch(
         branch,
         'test-branch',
-        { 'test-cta': mockCTA, 'secondary-cta': secondaryCTA },
-        {}
+        { 'test-cta': mockCTA, 'secondary-cta': secondaryCTA }
       );
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should warn if more than 3 total CTAs', () => {
+    it('should warn if total CTAs exceed the per-response cap', () => {
       const branch: ConversationBranch = {
         detection_keywords: ['test'],
         available_ctas: {
@@ -199,30 +127,16 @@ describe('Branch Validation', () => {
         'cta-3': mockCTA,
       };
 
-      const result = validateBranch(branch, 'test-branch', ctas, {});
+      // Pass an explicit cap of 3 so 4 total triggers the warning. The current
+      // signature takes maxCtasPerResponse (number) rather than allBranches.
+      const result = validateBranch(branch, 'test-branch', ctas, 3);
       expect(result.valid).toBe(true);
-      expect(result.warnings.some((w) => w.message.includes('too many'))).toBe(true);
-    });
-  });
-
-  describe('quality validation', () => {
-    it('should provide priority suggestion', () => {
-      const branch: ConversationBranch = {
-        detection_keywords: ['housing'],
-        available_ctas: {
-          primary: 'test-cta',
-          secondary: [],
-        },
-      };
-
-      const result = validateBranch(branch, 'test-branch', allCTAs, {});
-      expect(result.valid).toBe(true);
-      expect(result.warnings.some((w) => w.message.includes('priority'))).toBe(true);
+      expect(result.warnings.some((w) => w.message.toLowerCase().includes('too many'))).toBe(true);
     });
   });
 
   describe('bulk branch validation', () => {
-    it('should validate all branches', () => {
+    it('should validate all branches and surface errors from any invalid one', () => {
       const branches: Record<string, ConversationBranch> = {
         'branch-1': {
           detection_keywords: ['housing'],
@@ -232,9 +146,9 @@ describe('Branch Validation', () => {
           },
         },
         'branch-2': {
-          detection_keywords: [], // Invalid
+          detection_keywords: ['help'],
           available_ctas: {
-            primary: 'test-cta',
+            primary: '', // Invalid — missing primary CTA
             secondary: [],
           },
         },
@@ -248,16 +162,16 @@ describe('Branch Validation', () => {
     it('should collect all errors from multiple branches', () => {
       const branches: Record<string, ConversationBranch> = {
         'branch-1': {
-          detection_keywords: [],
+          detection_keywords: ['a'],
           available_ctas: {
-            primary: '',
+            primary: '', // missing primary
             secondary: [],
           },
         },
         'branch-2': {
           detection_keywords: ['test'],
           available_ctas: {
-            primary: 'nonexistent-cta',
+            primary: 'nonexistent-cta', // missing reference
             secondary: [],
           },
         },

--- a/src/lib/validation/__tests__/formValidation.test.ts
+++ b/src/lib/validation/__tests__/formValidation.test.ts
@@ -106,7 +106,8 @@ describe('Form Validation', () => {
 
       const result = validateForm(form, 'test-form', allPrograms);
       expect(result.valid).toBe(false);
-      expect(result.errors.some((e) => e.message.includes('duplicate'))).toBe(true);
+      // Current message starts with "Duplicate field ID" — match case-insensitively.
+      expect(result.errors.some((e) => e.message.toLowerCase().includes('duplicate'))).toBe(true);
     });
 
     it('should require options for select fields', () => {
@@ -209,37 +210,31 @@ describe('Form Validation', () => {
   });
 
   describe('trigger phrase validation', () => {
-    it('should warn if no trigger phrases', () => {
-      const form: ConversationalForm = {
+    // Note: trigger phrase validation was removed when forms moved to explicit
+    // CTA routing. `validateTriggerPhrases` in formValidation.ts is now a no-op.
+    // Empty or populated trigger_phrases should both validate cleanly.
+    it('should not warn about trigger phrases either way (feature removed)', () => {
+      const emptyForm: ConversationalForm = {
         enabled: true,
         form_id: 'test-form',
         program: 'test-program',
         title: 'Test Form',
         description: 'Test description',
-        trigger_phrases: [], // No trigger phrases
+        trigger_phrases: [],
         fields: [mockField],
       };
-
-      const result = validateForm(form, 'test-form', allPrograms);
-      expect(result.valid).toBe(true);
-      expect(result.warnings.some((w) => w.message.includes('trigger phrases'))).toBe(true);
-    });
-
-    it('should not warn with trigger phrases', () => {
-      const form: ConversationalForm = {
-        enabled: true,
-        form_id: 'test-form',
-        program: 'test-program',
-        title: 'Test Form',
-        description: 'Test description',
+      const populatedForm: ConversationalForm = {
+        ...emptyForm,
         trigger_phrases: ['apply', 'application'],
-        fields: [mockField],
       };
 
-      const result = validateForm(form, 'test-form', allPrograms);
-      expect(result.valid).toBe(true);
-      const triggerWarnings = result.warnings.filter((w) => w.message.includes('trigger'));
-      expect(triggerWarnings).toHaveLength(0);
+      const emptyResult = validateForm(emptyForm, 'test-form', allPrograms);
+      const populatedResult = validateForm(populatedForm, 'test-form', allPrograms);
+
+      expect(emptyResult.valid).toBe(true);
+      expect(populatedResult.valid).toBe(true);
+      expect(emptyResult.warnings.filter((w) => w.message.toLowerCase().includes('trigger'))).toHaveLength(0);
+      expect(populatedResult.warnings.filter((w) => w.message.toLowerCase().includes('trigger'))).toHaveLength(0);
     });
   });
 
@@ -268,7 +263,10 @@ describe('Form Validation', () => {
       expect(result.warnings.some((w) => w.message.includes('too many'))).toBe(true);
     });
 
-    it('should suggest email validation for required email fields', () => {
+    // Note: email/phone format-validation suggestions were removed. The
+    // comment in formValidation.ts explains: "Email and phone field types
+    // inherently provide format validation — No additional warnings needed."
+    it('should not warn about email fields (inherent format validation)', () => {
       const form: ConversationalForm = {
         enabled: true,
         form_id: 'test-form',
@@ -289,10 +287,10 @@ describe('Form Validation', () => {
 
       const result = validateForm(form, 'test-form', allPrograms);
       expect(result.valid).toBe(true);
-      expect(result.warnings.some((w) => w.message.includes('email'))).toBe(true);
+      expect(result.warnings.filter((w) => w.message.toLowerCase().includes('email'))).toHaveLength(0);
     });
 
-    it('should suggest phone validation for required phone fields', () => {
+    it('should not warn about phone fields (inherent format validation)', () => {
       const form: ConversationalForm = {
         enabled: true,
         form_id: 'test-form',
@@ -313,7 +311,7 @@ describe('Form Validation', () => {
 
       const result = validateForm(form, 'test-form', allPrograms);
       expect(result.valid).toBe(true);
-      expect(result.warnings.some((w) => w.message.includes('phone'))).toBe(true);
+      expect(result.warnings.filter((w) => w.message.toLowerCase().includes('phone'))).toHaveLength(0);
     });
   });
 

--- a/src/lib/validation/__tests__/relationshipValidation.test.ts
+++ b/src/lib/validation/__tests__/relationshipValidation.test.ts
@@ -215,7 +215,8 @@ describe('Relationship Validation', () => {
         branches
       );
       expect(result.valid).toBe(false);
-      expect(result.errors.some((e) => e.message.includes('secondary'))).toBe(true);
+      // Message is "Secondary CTA ..." — match case-insensitively.
+      expect(result.errors.some((e) => e.message.toLowerCase().includes('secondary'))).toBe(true);
     });
 
     it('should validate valid branch → CTA relationship', () => {
@@ -233,8 +234,12 @@ describe('Relationship Validation', () => {
   });
 
   describe('circular dependency detection', () => {
-    it('should warn about trigger phrases matching confirmation messages', () => {
-      const formWithCircular: ConversationalForm = {
+    // Note: trigger-phrase-vs-confirmation-message circular detection was
+    // removed when forms moved to explicit CTA routing. The check in
+    // `detectCircularDependencies` is now a no-op. Both shapes below should
+    // validate cleanly without emitting a "circular" warning.
+    it('should not warn about trigger-phrase/confirmation overlap (feature removed)', () => {
+      const formWithOverlap: ConversationalForm = {
         ...mockForm,
         trigger_phrases: ['apply for housing'],
         post_submission: {
@@ -245,32 +250,14 @@ describe('Relationship Validation', () => {
 
       const result = validateRelationships(
         { 'test-program': mockProgram },
-        { 'test-form': formWithCircular },
+        { 'test-form': formWithOverlap },
         {},
         {}
       );
 
-      expect(result.warnings.some((w) => w.message.includes('circular'))).toBe(true);
-    });
-
-    it('should not warn about unrelated trigger phrases and confirmations', () => {
-      const formWithoutCircular: ConversationalForm = {
-        ...mockForm,
-        trigger_phrases: ['apply'],
-        post_submission: {
-          confirmation_message: 'Thank you for your submission!',
-          actions: [],
-        },
-      };
-
-      const result = validateRelationships(
-        { 'test-program': mockProgram },
-        { 'test-form': formWithoutCircular },
-        {},
-        {}
+      const circularWarnings = result.warnings.filter((w) =>
+        w.message.toLowerCase().includes('circular')
       );
-
-      const circularWarnings = result.warnings.filter((w) => w.message.includes('circular'));
       expect(circularWarnings).toHaveLength(0);
     });
   });
@@ -288,7 +275,7 @@ describe('Relationship Validation', () => {
       const forms = { 'test-form': mockForm };
 
       const result = validateRelationships(programs, forms, {}, {});
-      expect(result.warnings.some((w) => w.message.includes('orphaned'))).toBe(true);
+      expect(result.warnings.some((w) => w.message.toLowerCase().includes('orphaned'))).toBe(true);
       expect(result.warnings.some((w) => w.message.includes('unused-program'))).toBe(true);
     });
 
@@ -312,7 +299,7 @@ describe('Relationship Validation', () => {
         ctas,
         branches
       );
-      expect(result.warnings.some((w) => w.message.includes('orphaned'))).toBe(true);
+      expect(result.warnings.some((w) => w.message.toLowerCase().includes('orphaned'))).toBe(true);
       expect(result.warnings.some((w) => w.message.includes('unused-cta'))).toBe(true);
     });
 
@@ -324,7 +311,7 @@ describe('Relationship Validation', () => {
         { 'test-branch': mockBranch }
       );
 
-      const orphanedWarnings = result.warnings.filter((w) => w.message.includes('orphaned'));
+      const orphanedWarnings = result.warnings.filter((w) => w.message.toLowerCase().includes('orphaned'));
       expect(orphanedWarnings).toHaveLength(0);
     });
   });

--- a/src/lib/validation/__tests__/validation.test.ts
+++ b/src/lib/validation/__tests__/validation.test.ts
@@ -120,14 +120,17 @@ describe('Validation Engine', () => {
       expect(result.errors.some((e) => e.message.includes('does not exist'))).toBe(true);
     });
 
-    it('should warn about missing trigger phrases', () => {
+    // Note: trigger phrase warnings were removed when forms moved to explicit
+    // CTA routing. A form with empty trigger_phrases should validate cleanly
+    // with no warnings about trigger phrases.
+    it('should not warn about empty trigger_phrases (feature removed)', () => {
       const form: ConversationalForm = {
         enabled: true,
         form_id: 'test-form',
         program: 'test-program',
         title: 'Test Form',
         description: 'Test description',
-        trigger_phrases: [], // No trigger phrases
+        trigger_phrases: [],
         fields: [
           {
             id: 'name',
@@ -142,8 +145,7 @@ describe('Validation Engine', () => {
       const result = validateForm(form, 'test-form', { 'test-program': testProgram });
 
       expect(result.valid).toBe(true);
-      expect(result.warnings).toHaveLength(1);
-      expect(result.warnings[0].message).toContain('trigger phrases');
+      expect(result.warnings.filter((w) => w.message.toLowerCase().includes('trigger'))).toHaveLength(0);
     });
   });
 
@@ -156,19 +158,21 @@ describe('Validation Engine', () => {
       style: 'primary',
     };
 
-    it('should require at least one keyword', () => {
+    // Note: `detection_keywords` and `question words` rules were removed when
+    // V4 routing moved CTA selection to the LLM-based action selector. A
+    // branch with empty keywords is now valid; question-word content is no
+    // longer inspected. The primary-CTA check remains.
+    it('should allow branches without keywords (feature removed)', () => {
       const branch: ConversationBranch = {
-        detection_keywords: [], // No keywords
+        detection_keywords: [],
         available_ctas: {
           primary: 'test-cta',
           secondary: [],
         },
       };
 
-      const result = validateBranch(branch, 'test-branch', { 'test-cta': testCTA }, {});
-
-      expect(result.valid).toBe(false);
-      expect(result.errors.some((e) => e.message.includes('keyword'))).toBe(true);
+      const result = validateBranch(branch, 'test-branch', { 'test-cta': testCTA });
+      expect(result.valid).toBe(true);
     });
 
     it('should require primary CTA', () => {
@@ -180,25 +184,10 @@ describe('Validation Engine', () => {
         },
       };
 
-      const result = validateBranch(branch, 'test-branch', { 'test-cta': testCTA }, {});
+      const result = validateBranch(branch, 'test-branch', { 'test-cta': testCTA });
 
       expect(result.valid).toBe(false);
       expect(result.errors.some((e) => e.message.includes('primary CTA'))).toBe(true);
-    });
-
-    it('should warn about question words in keywords', () => {
-      const branch: ConversationBranch = {
-        detection_keywords: ['how do I apply', 'what is this'],
-        available_ctas: {
-          primary: 'test-cta',
-          secondary: [],
-        },
-      };
-
-      const result = validateBranch(branch, 'test-branch', { 'test-cta': testCTA }, {});
-
-      expect(result.valid).toBe(true);
-      expect(result.warnings.some((w) => w.message.includes('question words'))).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

19 failing validation unit tests across 5 files, all pre-existing on `main`. The validator drifted from the tests when V4 routing and explicit CTA routing landed. This PR updates **tests only** — no production code changes.

### Rules no longer enforced (tests updated to match)
- Branch `detection_keywords` required — V4 uses the LLM action selector
- Branch question-word warnings
- Branch cross-branch keyword overlap detection (the signature no longer takes \`allBranches\`)
- Branch priority suggestion warning
- Form no-trigger-phrases warning — forms use explicit CTA routing
- Form email/phone format-validation suggestions — the field type provides format validation inherently
- Trigger-phrase/confirmation-message circular dependency detection

### Case-sensitivity fixes
Several assertions used \`.includes('foo')\` against messages starting with a capital ("Duplicate", "Secondary", "Orphaned"). Switched to \`.toLowerCase().includes(...)\`.

### Type guard
\`isValidBranch\` now validates structural shape only — inverted the "reject branches without keywords" test to reflect this.

## Related
- PR #4 (\`fix: align integration tests with current store/validation API\`) — same drift pattern, different files.
- This is part of a sweep to turn CI green. Three more PRs to follow: integration workflow tests, store \`markDirty\` propagation, component tests.

## Test plan
- [x] \`npx vitest run src/lib/validation/__tests__/ src/lib/utils/__tests__/type-guards.test.ts\` — 139/139 pass locally
- [ ] CI \`Unit Test Coverage\` job moves from 19 more passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)