### PR TITLE
feat: ETag-based optimistic concurrency on config save

### DIFF
--- a/src/__tests__/integration/testUtils.ts
+++ b/src/__tests__/integration/testUtils.ts
@@ -214,12 +214,13 @@ export function createMockS3API() {
           version: config.version,
           lastModified: config.generated_at,
         },
+        etag: `"mock-etag-${tenantId}-${config.generated_at}"`,
       });
     }),
 
     saveConfig: vi.fn((tenantId: string, config: TenantConfig) => {
       mockConfigs.set(tenantId, config);
-      return Promise.resolve();
+      return Promise.resolve({ etag: `"mock-etag-${tenantId}-${Date.now()}"` });
     }),
 
     deployConfig: vi.fn((tenantId: string, config: TenantConfig) => {

--- a/src/components/layout/ConflictBanner.tsx
+++ b/src/components/layout/ConflictBanner.tsx
@@ -1,0 +1,58 @@
+/**
+ * ConflictBanner Component
+ * Shown when a save is rejected with 409 because the config was
+ * updated elsewhere. The user's in-progress edits remain in the
+ * store — only baseConfig needs to be refreshed so the next save
+ * sends a fresh If-Match ETag.
+ */
+
+import React, { useState } from 'react';
+import { AlertCircle } from 'lucide-react';
+import { Button } from '../ui';
+import { useConfigStore } from '@/store';
+
+export const ConflictBanner: React.FC = () => {
+  const conflictState = useConfigStore((state) => state.config.conflictState);
+  const tenantId = useConfigStore((state) => state.config.tenantId);
+  const loadConfig = useConfigStore((state) => state.config.loadConfig);
+  const clearConflict = useConfigStore((state) => state.config.clearConflict);
+
+  const [reloading, setReloading] = useState(false);
+
+  if (!conflictState || !tenantId) return null;
+
+  const handleReload = async () => {
+    setReloading(true);
+    try {
+      await loadConfig(tenantId);
+    } finally {
+      setReloading(false);
+    }
+  };
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex items-start gap-3 border-l-4 border-amber-500 bg-amber-50 px-4 py-3"
+    >
+      <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" aria-hidden="true" />
+      <div className="flex-1">
+        <p className="font-semibold text-amber-900">Config was updated elsewhere</p>
+        <p className="text-sm text-amber-800">
+          Your save was blocked because another process modified this tenant's config
+          since you loaded it. Reload to apply your changes on top of the latest version —
+          your unsaved edits stay in the editor.
+        </p>
+      </div>
+      <div className="flex flex-shrink-0 gap-2">
+        <Button variant="primary" size="sm" onClick={handleReload} disabled={reloading}>
+          {reloading ? 'Reloading…' : 'Reload latest'}
+        </Button>
+        <Button variant="secondary" size="sm" onClick={clearConflict} disabled={reloading}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,6 +9,7 @@ import { Header } from './Header';
 import { Sidebar } from './Sidebar';
 import { MainContent } from './MainContent';
 import { ValidationPanel } from './ValidationPanel';
+import { ConflictBanner } from './ConflictBanner';
 
 /**
  * Application Layout
@@ -30,6 +31,10 @@ export const Layout: React.FC = () => {
     <div className="app-layout">
       {/* Header */}
       <Header />
+
+      {/* Concurrency-conflict banner — renders only when a save was
+          blocked by a 409 and we need to prompt the user to reload. */}
+      <ConflictBanner />
 
       {/* Main Content Area */}
       <div className="app-main-wrapper">

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -7,6 +7,7 @@ export { Header } from './Header';
 export { Sidebar } from './Sidebar';
 export { MainContent } from './MainContent';
 export { Breadcrumbs } from './Breadcrumbs';
+export { ConflictBanner } from './ConflictBanner';
 export { ValidationPanel } from './ValidationPanel';
 export { ValidationSummary } from './ValidationSummary';
 export { EntityValidationBadge } from './EntityValidationBadge';

--- a/src/lib/api/__mocks__/config-operations.ts
+++ b/src/lib/api/__mocks__/config-operations.ts
@@ -89,11 +89,14 @@ export const mockLoadConfig = async (tenantId: string): Promise<LoadConfigRespon
       ...mockMetadata,
       tenantId,
     },
+    etag: '"mock-etag"',
   };
 };
 
-export const mockSaveConfig = async (): Promise<void> => {
-  // Mock successful save
+export const mockSaveConfig = async (): Promise<{ etag?: string }> => {
+  // Mock successful save — return a synthetic etag so store state can
+  // refresh its optimistic-concurrency token after the write.
+  return { etag: '"mock-etag"' };
 };
 
 export const mockDeployConfig = async (): Promise<void> => {

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -155,6 +155,10 @@ export class ConfigAPIClient {
         throw new ConfigAPIError('INVALID_CONFIG', 'Response missing config field');
       }
 
+      // Prefer the ETag response header (wire-native), fall back to the
+      // body field for API Gateway deployments that strip ETag.
+      const etag = response.headers.get('ETag') || data.etag || undefined;
+
       return {
         config: data.config as TenantConfig,
         metadata: data.metadata || {
@@ -163,6 +167,7 @@ export class ConfigAPIClient {
           lastModified: Date.now(),
           configVersion: data.config.version || '1.0',
         },
+        etag,
       };
     });
   }
@@ -174,7 +179,7 @@ export class ConfigAPIClient {
   async saveConfig(
     tenantId: string,
     config: TenantConfig,
-    options: { createBackup?: boolean } = {}
+    options: { createBackup?: boolean; ifMatch?: string } = {}
   ): Promise<SaveConfigResponse> {
     if (!tenantId || tenantId.trim() === '') {
       throw new ConfigAPIError('INVALID_TENANT_ID', 'Tenant ID cannot be empty');
@@ -207,6 +212,7 @@ export class ConfigAPIClient {
           headers: {
             'Content-Type': 'application/json',
             ...(await this.getAuthHeaders()),
+            ...(options.ifMatch && { 'If-Match': options.ifMatch }),
           },
           body: JSON.stringify(requestBody),
         });
@@ -216,11 +222,34 @@ export class ConfigAPIClient {
           throw await parseHTTPError(response);
         }
 
+        // 409 Conflict means the server detected an ETag mismatch.
+        // Surface a typed error carrying the server's current config +
+        // etag so the UI can prompt the user to reload without losing
+        // their local edits.
+        if (response.status === 409) {
+          let details: unknown = undefined;
+          try {
+            details = await response.json();
+          } catch {
+            // ignore JSON parse failures; details stays undefined
+          }
+          throw new ConfigAPIError(
+            'VERSION_CONFLICT',
+            'This config was updated elsewhere while you were editing. Reload to apply your changes on top of the latest version.',
+            details,
+            409
+          );
+        }
+
         if (!response.ok) {
           throw await parseHTTPError(response);
         }
 
-        return response.json();
+        const data = await response.json();
+        // Attach the new ETag from the response header as a fallback
+        // for callers that need to chain another save.
+        const etag = response.headers.get('ETag') || data.etag || undefined;
+        return { ...data, etag } as SaveConfigResponse;
       },
       {
         maxRetries: 2, // Save operations get fewer retries

--- a/src/lib/api/config-operations.ts
+++ b/src/lib/api/config-operations.ts
@@ -72,8 +72,8 @@ export async function loadConfig(tenantId: string): Promise<LoadConfigResponse> 
 export async function saveConfig(
   tenantId: string,
   config: TenantConfig,
-  options: { createBackup?: boolean } = {}
-): Promise<void> {
+  options: { createBackup?: boolean; ifMatch?: string } = {}
+): Promise<{ etag?: string }> {
   try {
     if (!tenantId || tenantId.trim() === '') {
       throw new ConfigAPIError('INVALID_TENANT_ID', 'Tenant ID is required');
@@ -91,7 +91,8 @@ export async function saveConfig(
       version: incrementVersion(config.version),
     };
 
-    await configApiClient.saveConfig(tenantId, updatedConfig, options);
+    const result = await configApiClient.saveConfig(tenantId, updatedConfig, options);
+    return { etag: result.etag };
   } catch (error) {
     throw handleAPIError(error);
   }

--- a/src/store/slices/config.ts
+++ b/src/store/slices/config.ts
@@ -7,13 +7,17 @@ import type { TenantConfig } from '@/types/config';
 import type { SliceCreator, ConfigSlice } from '../types';
 import * as configAPI from '@/lib/api/config-operations';
 import { configApiClient } from '@/lib/api/client';
+import { ConfigAPIError } from '@/lib/api/errors';
 
 export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
   // State
   tenantId: null,
   baseConfig: null,
+  etag: null,
   isDirty: false,
   lastSaved: null,
+
+  conflictState: null,
 
   // Draft state
   isDraft: false,
@@ -36,6 +40,8 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         // Update config slice
         state.config.tenantId = tenantId;
         state.config.baseConfig = response.config;
+        state.config.etag = response.etag ?? null;
+        state.config.conflictState = null;
         state.config.isDirty = false;
         state.config.lastSaved = response.metadata.lastModified;
 
@@ -124,13 +130,16 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         throw new Error('Failed to merge configuration');
       }
 
-      await configAPI.saveConfig(state.config.tenantId, mergedConfig, {
+      const saveResult = await configAPI.saveConfig(state.config.tenantId, mergedConfig, {
         createBackup: true,
+        ifMatch: state.config.etag ?? undefined,
       });
 
       // Update base config and mark clean
       set((state) => {
         state.config.baseConfig = mergedConfig;
+        state.config.etag = saveResult.etag ?? null;
+        state.config.conflictState = null;
         state.config.isDirty = false;
         state.config.lastSaved = Date.now();
       });
@@ -140,6 +149,22 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         message: 'Configuration saved successfully',
       });
     } catch (error) {
+      // ETag mismatch: stash the server's current state so the UI can
+      // render a reload banner. Skip the generic error toast — the
+      // banner is a richer, less alarming signal for this case.
+      if (error instanceof ConfigAPIError && error.code === 'VERSION_CONFLICT') {
+        const details = (error.details ?? {}) as {
+          currentConfig?: TenantConfig;
+          currentETag?: string;
+        };
+        set((state) => {
+          state.config.conflictState = {
+            currentConfig: details.currentConfig ?? null,
+            currentETag: details.currentETag ?? null,
+          };
+        });
+        throw error;
+      }
       const errorMessage = error instanceof Error ? error.message : 'Failed to save configuration';
       state.ui.addToast({
         type: 'error',
@@ -295,6 +320,8 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
     set((state) => {
       state.config.tenantId = null;
       state.config.baseConfig = null;
+      state.config.etag = null;
+      state.config.conflictState = null;
       state.config.isDirty = false;
       state.config.lastSaved = null;
       state.config.isDraft = false;
@@ -306,6 +333,12 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
       state.branches.branches = {};
       state.contentShowcase.content_showcase = [];
       state.validation.clearAll();
+    });
+  },
+
+  clearConflict: () => {
+    set((state) => {
+      state.config.conflictState = null;
     });
   },
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -234,12 +234,34 @@ export interface ValidationSlice {
 // CONFIG SLICE
 // ============================================================================
 
+/**
+ * State tracked when the server rejects a save with 409 Conflict
+ * because another writer modified the config since the current user
+ * loaded it. The UI reads this to show the reload banner.
+ */
+export interface ConfigConflictState {
+  currentConfig: TenantConfig | null;
+  currentETag: string | null;
+}
+
 export interface ConfigSlice {
   // Loaded config state
   tenantId: string | null;
   baseConfig: TenantConfig | null;
+  /**
+   * S3 ETag of baseConfig. Sent as If-Match on saves to detect
+   * concurrent modifications. Null between tenant switches.
+   */
+  etag: string | null;
   isDirty: boolean;
   lastSaved: number | null;
+
+  /**
+   * Non-null when the last save hit a 409 Conflict. UI should render
+   * a reload banner. Cleared on successful reload + re-save or by
+   * the user dismissing the banner.
+   */
+  conflictState: ConfigConflictState | null;
 
   // Draft state
   isDraft: boolean;
@@ -252,6 +274,7 @@ export interface ConfigSlice {
   deployConfig: () => Promise<void>;
   resetConfig: () => void;
   clearTenant: () => void;
+  clearConflict: () => void;
   markDirty: () => void;
   markClean: () => void;
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -52,6 +52,13 @@ export interface LoadConfigRequest {
 export interface LoadConfigResponse {
   config: TenantConfig;
   metadata: TenantMetadata;
+  /**
+   * S3 ETag of the loaded config object. Callers should pass this back as
+   * the `ifMatch` option on the corresponding save to get optimistic
+   * concurrency control; the server returns 409 if another writer has
+   * modified the object in the meantime.
+   */
+  etag?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Frontend companion to the Picasso_Config_Manager ETag backend change (Phase 0.5 of the KB freshness system — see lambda repo PR #8). The config builder now sends the ETag it received on load as If-Match on every save, and renders a non-destructive reload banner when the server returns 409 because another writer modified the config in the meantime.

### Changes
- **Types** — `LoadConfigResponse.etag`, `ConfigSlice.etag`, `ConfigSlice.conflictState`, `ConfigSlice.clearConflict()`
- **Client** — `loadConfig` captures ETag from response header (with body fallback); `saveConfig` accepts `ifMatch` option → sends `If-Match` header; on 409, throws typed `VERSION_CONFLICT` error carrying server's `{currentConfig, currentETag}`
- **Store** — threads etag through load/save; on 409 stashes conflict state and suppresses the generic error toast (banner is the richer signal)
- **UI** — new `ConflictBanner` renders between Header and main content when a conflict is active; "Reload latest" re-fetches base config while preserving in-progress domain-slice edits; "Dismiss" clears the banner

## Test plan
- [x] `npm run typecheck` introduces zero new type errors (8 pre-existing errors on main remain, all unrelated — App.tsx unused imports, Select typo in PostSubmissionConfig, missing draft method typings on ConfigAPIClient)
- [ ] Manual: open two browser sessions, edit same tenant in both; first save succeeds, second save shows banner; click Reload → base config refreshes + in-progress edits preserved; next save succeeds
- [ ] Manual: Dismiss button clears the banner without side effects

## Not in this PR
- Backend ETag implementation — separate PR in the lambda submodule ([lambda#8](https://github.com/longhornrumble/lambda/pull/8))
- Main-repo submodule bump — coming after both submodule PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)