### PR TITLE
feat(kb-freshness): Phase 2 — Pending Changes review UI (read-only)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   BranchesPage,
   ActionChipsPage,
   CardsPage,
+  PendingChangesPage,
   SettingsPage,
   NotFoundPage,
 } from './pages';
@@ -125,6 +126,9 @@ function renderApp() {
 
             {/* Card inventory section (optional) */}
             <Route path="cards" element={<CardsPage />} />
+
+            {/* KB-freshness review (read-only in Phase 2) */}
+            <Route path="pending-changes" element={<PendingChangesPage />} />
 
             {/* Settings section */}
             <Route path="settings" element={<SettingsPage />} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   GitBranch,
   Zap,
   Sparkles,
+  ClipboardList,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -93,6 +94,11 @@ export const Sidebar: React.FC = () => {
       to: '/cards',
       label: 'Showcase Items',
       icon: <Sparkles className="w-5 h-5" />,
+    },
+    {
+      to: '/pending-changes',
+      label: 'Pending Changes',
+      icon: <ClipboardList className="w-5 h-5" />,
     },
     {
       to: '/settings',

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -13,6 +13,7 @@ import type {
   SaveConfigResponse,
   TenantMetadata,
 } from '@/types/api';
+import type { Proposal } from '@/types/proposals';
 
 // Get API URL from environment
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://api.yourapi.com/api';
@@ -384,6 +385,41 @@ export class ConfigAPIClient {
         maxRetries: 2,
       }
     );
+  }
+
+  /**
+   * List pending KB-freshness proposals for a tenant.
+   * Returns the proposals newest-first; empty array if none.
+   */
+  async listProposals(tenantId: string): Promise<Proposal[]> {
+    if (!tenantId || tenantId.trim() === '') {
+      throw new ConfigAPIError('INVALID_TENANT_ID', 'Tenant ID cannot be empty');
+    }
+
+    return fetchWithRetry(async () => {
+      const response = await fetch(
+        `${this.baseUrl}/proposals?tenantId=${encodeURIComponent(tenantId)}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(await this.getAuthHeaders()),
+          },
+        }
+      );
+
+      if (response.status === 401) {
+        this.handle401Response();
+        throw await parseHTTPError(response);
+      }
+
+      if (!response.ok) {
+        throw await parseHTTPError(response);
+      }
+
+      const data = await response.json();
+      return (data.proposals || []) as Proposal[];
+    });
   }
 
   /**

--- a/src/pages/PendingChangesPage.tsx
+++ b/src/pages/PendingChangesPage.tsx
@@ -1,0 +1,330 @@
+/**
+ * PendingChangesPage
+ *
+ * Read-only list of pending KB-freshness proposals for the current tenant.
+ * Phase 2 of the KB Freshness + Content Lifecycle System — displays what
+ * the scanner has proposed. Approve/reject/apply ships in Phase 3.
+ *
+ * See docs/roadmap/KB_FRESHNESS_LIFECYCLE_SYSTEM.md for schema + context.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { ClipboardList, RefreshCw, AlertCircle } from 'lucide-react';
+import { Badge, Button, Spinner, Alert, AlertTitle, AlertDescription } from '@/components/ui';
+import { configApiClient } from '@/lib/api/client';
+import { useConfigStore } from '@/store';
+import type { Proposal, ProposalItem, ProposalOperation } from '@/types/proposals';
+
+export const PendingChangesPage: React.FC = () => {
+  const tenantId = useConfigStore((state) => state.config.tenantId);
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    if (!tenantId) {
+      setProposals([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await configApiClient.listProposals(tenantId);
+      setProposals(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load proposals');
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (!tenantId) {
+    return (
+      <div className="space-y-6">
+        <PageHeader />
+        <Alert>
+          <AlertCircle className="w-4 h-4" />
+          <AlertTitle>No tenant selected</AlertTitle>
+          <AlertDescription>
+            Select a tenant from the Home page to see its pending KB-freshness proposals.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <PageHeader tenantId={tenantId} count={proposals.length} />
+        <Button variant="secondary" onClick={load} disabled={loading}>
+          <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <Alert variant="error">
+          <AlertCircle className="w-4 h-4" />
+          <AlertTitle>Couldn't load proposals</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {loading && proposals.length === 0 && (
+        <div className="flex items-center justify-center py-12">
+          <Spinner />
+        </div>
+      )}
+
+      {!loading && !error && proposals.length === 0 && (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-12 text-center">
+          <ClipboardList className="w-10 h-10 mx-auto text-gray-400 mb-3" />
+          <p className="text-gray-600 dark:text-gray-300 font-medium">No pending proposals</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            The scanner will post here when it detects material KB changes.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {proposals.map((p) => (
+          <ProposalCard key={p.proposalId} proposal={p} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const PageHeader: React.FC<{ tenantId?: string; count?: number }> = ({ tenantId, count }) => (
+  <div>
+    <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-3">
+      <ClipboardList className="w-8 h-8 text-teal-600 dark:text-teal-400" />
+      Pending Changes
+    </h1>
+    {tenantId && (
+      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        {count ?? 0} proposal{count === 1 ? '' : 's'} for {tenantId}
+      </p>
+    )}
+  </div>
+);
+
+const ProposalCard: React.FC<{ proposal: Proposal }> = ({ proposal }) => {
+  const { summary } = proposal;
+  const created = new Date(proposal.createdAt).toLocaleString();
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+      <div className="px-5 py-3 bg-teal-50 dark:bg-teal-900/20 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <div className="font-semibold text-gray-900 dark:text-gray-100">
+            {proposal.siteUrl}
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {proposal.proposalId} · {created}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {summary.additions > 0 && (
+            <Badge className="bg-emerald-100 text-emerald-800 border-emerald-200">
+              {summary.additions} addition{summary.additions === 1 ? '' : 's'}
+            </Badge>
+          )}
+          {summary.edits > 0 && (
+            <Badge className="bg-amber-100 text-amber-800 border-amber-200">
+              {summary.edits} edit{summary.edits === 1 ? '' : 's'}
+            </Badge>
+          )}
+          {summary.retirements > 0 && (
+            <Badge className="bg-rose-100 text-rose-800 border-rose-200">
+              {summary.retirements} retirement{summary.retirements === 1 ? '' : 's'}
+            </Badge>
+          )}
+          {summary.skipped > 0 && (
+            <Badge variant="secondary">{summary.skipped} skipped</Badge>
+          )}
+        </div>
+      </div>
+
+      {proposal.items.length === 0 ? (
+        <div className="p-5 text-sm text-gray-500 dark:text-gray-400 italic">
+          No items — heartbeat proposal (inventory only).
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-100 dark:divide-gray-700">
+          {proposal.items.map((item) => (
+            <ProposalItemRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ProposalItemRow: React.FC<{ item: ProposalItem }> = ({ item }) => {
+  return (
+    <div className="px-5 py-4">
+      <div className="flex items-start justify-between gap-4 mb-2">
+        <div className="min-w-0">
+          <div className="font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2 flex-wrap">
+            <span>{titleForItem(item)}</span>
+            <TypeChip type={item.type} />
+            {item.severity && <SeverityChip severity={item.severity} />}
+          </div>
+          {item.sourceUrl && (
+            <a
+              href={item.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-teal-700 dark:text-teal-400 hover:underline break-all"
+            >
+              → {item.sourceUrl}
+            </a>
+          )}
+          {item.rationale && (
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{item.rationale}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-2 space-y-2">
+        {item.operations.map((op, idx) => (
+          <OperationPreview key={idx} op={op} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const TypeChip: React.FC<{ type: ProposalItem['type'] }> = ({ type }) => {
+  const classes = typeChipClass(type);
+  const label = type.replace(/_/g, ' ');
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${classes}`}>
+      {label}
+    </span>
+  );
+};
+
+const SeverityChip: React.FC<{ severity: 'high' | 'medium' | 'low' }> = ({ severity }) => {
+  const color =
+    severity === 'high'
+      ? 'bg-rose-100 text-rose-800'
+      : severity === 'medium'
+        ? 'bg-amber-100 text-amber-800'
+        : 'bg-gray-100 text-gray-700';
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
+      {severity}
+    </span>
+  );
+};
+
+const OperationPreview: React.FC<{ op: ProposalOperation }> = ({ op }) => {
+  return (
+    <div className="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 px-3 py-2 text-sm">
+      <div className="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-semibold mb-1">
+        {op.verb}
+      </div>
+      <OperationBody op={op} />
+    </div>
+  );
+};
+
+const OperationBody: React.FC<{ op: ProposalOperation }> = ({ op }) => {
+  switch (op.verb) {
+    case 'kb.append':
+      return (
+        <>
+          <div className="text-xs text-gray-500 mb-1">
+            after <code>{op.afterMarker}</code>
+          </div>
+          <pre className="bg-emerald-50 dark:bg-emerald-900/20 text-emerald-900 dark:text-emerald-200 p-2 rounded text-xs overflow-x-auto whitespace-pre-wrap">
+            {op.markdown}
+          </pre>
+        </>
+      );
+    case 'kb.replace':
+      return (
+        <>
+          <div className="text-xs text-gray-500 mb-1">
+            replaces section at <code>{op.sourceMarker}</code>
+          </div>
+          <pre className="bg-amber-50 dark:bg-amber-900/20 text-amber-900 dark:text-amber-200 p-2 rounded text-xs overflow-x-auto whitespace-pre-wrap">
+            {op.markdown}
+          </pre>
+        </>
+      );
+    case 'kb.remove':
+      return (
+        <div className="text-xs text-gray-700 dark:text-gray-300">
+          remove section at <code>{op.sourceMarker}</code>
+        </div>
+      );
+    case 'config.add':
+      return (
+        <>
+          <div className="text-xs text-gray-500 mb-1">
+            add to <code>{op.path}</code>
+          </div>
+          <pre className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 p-2 rounded text-xs overflow-x-auto">
+            {JSON.stringify(op.value, null, 2)}
+          </pre>
+        </>
+      );
+    case 'config.delete':
+      return (
+        <div className="text-xs text-gray-700 dark:text-gray-300">
+          delete from <code>{op.path}</code> where <code>{op.matchBy}</code> =
+          <code> {op.matchValue}</code>
+        </div>
+      );
+    case 'config.append_to_array':
+      return (
+        <div className="text-xs text-gray-700 dark:text-gray-300">
+          append <code>{op.value}</code> to <code>{op.path}</code>
+        </div>
+      );
+    case 'dub.upsert':
+      return (
+        <div className="text-xs text-gray-700 dark:text-gray-300">
+          shortlink <code>{op.slug}</code> → <code>{op.url}</code>
+        </div>
+      );
+    default:
+      return (
+        <pre className="text-xs overflow-x-auto">{JSON.stringify(op, null, 2)}</pre>
+      );
+  }
+};
+
+function titleForItem(item: ProposalItem): string {
+  switch (item.type) {
+    case 'new_event':
+      return 'New event';
+    case 'new_staff':
+      return 'New staff member';
+    case 'new_content':
+      return 'New content';
+    case 'page_edit':
+      return 'Page edit';
+    case 'stale_event':
+      return 'Retire expired event';
+    case 'stale_content':
+      return 'Retire stale content';
+    default:
+      return item.type;
+  }
+}
+
+function typeChipClass(type: ProposalItem['type']): string {
+  if (type.startsWith('new')) return 'bg-emerald-100 text-emerald-800';
+  if (type === 'page_edit') return 'bg-amber-100 text-amber-800';
+  if (type.startsWith('stale')) return 'bg-rose-100 text-rose-800';
+  return 'bg-gray-100 text-gray-800';
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -10,5 +10,6 @@ export { CTAsPage } from './CTAsPage';
 export { BranchesPage } from './BranchesPage';
 export { ActionChipsPage } from './ActionChipsPage';
 export { CardsPage } from './CardsPage';
+export { PendingChangesPage } from './PendingChangesPage';
 export { SettingsPage } from './SettingsPage';
 export { NotFoundPage } from './NotFoundPage';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,24 @@ export type {
   OperationState,
 } from './api';
 
+// Proposal types (KB-freshness review)
+export type {
+  Proposal,
+  ProposalItem,
+  ProposalItemType,
+  ProposalSeverity,
+  ProposalStatus,
+  ProposalSummary,
+  ProposalOperation,
+  KbAppendOp,
+  KbReplaceOp,
+  KbRemoveOp,
+  ConfigAddOp,
+  ConfigDeleteOp,
+  ConfigAppendToArrayOp,
+  DubUpsertOp,
+} from './proposals';
+
 // UI types
 export type {
   ProgramListItem,

--- a/src/types/proposals.ts
+++ b/src/types/proposals.ts
@@ -1,0 +1,108 @@
+/**
+ * KB-freshness proposal types.
+ * Mirrors the schema produced by `picasso-webscraping/rag-scraper/scanner/agent-runner.ts`
+ * and documented in `picasso-webscraping/rag-scraper/skills/kb-proposal/SKILL.md`.
+ */
+
+export type ProposalItemType =
+  | 'new_event'
+  | 'new_staff'
+  | 'new_content'
+  | 'page_edit'
+  | 'stale_event'
+  | 'stale_content';
+
+export type ProposalSeverity = 'high' | 'medium' | 'low';
+
+export type ProposalStatus =
+  | 'pending'
+  | 'applied'
+  | 'partial_apply_error'
+  | 'rejected';
+
+export interface KbAppendOp {
+  verb: 'kb.append';
+  afterMarker: string;
+  sourceMarker: string;
+  markdown: string;
+}
+
+export interface KbReplaceOp {
+  verb: 'kb.replace';
+  sourceMarker: string;
+  markdown: string;
+}
+
+export interface KbRemoveOp {
+  verb: 'kb.remove';
+  sourceMarker: string;
+}
+
+export interface ConfigAddOp {
+  verb: 'config.add';
+  path: string;
+  value: Record<string, unknown>;
+}
+
+export interface ConfigDeleteOp {
+  verb: 'config.delete';
+  path: string;
+  matchBy: string;
+  matchValue: string;
+}
+
+export interface ConfigAppendToArrayOp {
+  verb: 'config.append_to_array';
+  path: string;
+  value: string;
+}
+
+export interface DubUpsertOp {
+  verb: 'dub.upsert';
+  externalId: string;
+  url: string;
+  slug: string;
+}
+
+export type ProposalOperation =
+  | KbAppendOp
+  | KbReplaceOp
+  | KbRemoveOp
+  | ConfigAddOp
+  | ConfigDeleteOp
+  | ConfigAppendToArrayOp
+  | DubUpsertOp;
+
+export interface ProposalItem {
+  id: string;
+  type: ProposalItemType;
+  sourceUrl?: string;
+  severity?: ProposalSeverity;
+  rationale?: string;
+  operations: ProposalOperation[];
+  applicationResult?: {
+    status: 'applied' | 'error';
+    error?: string;
+  } | null;
+}
+
+export interface ProposalSummary {
+  additions: number;
+  edits: number;
+  retirements: number;
+  skipped: number;
+}
+
+export interface Proposal {
+  proposalId: string;
+  tenantId: string;
+  createdAt: string;
+  status: ProposalStatus;
+  siteUrl: string;
+  summary: ProposalSummary;
+  applicationResult: unknown | null;
+  items: ProposalItem[];
+  inventorySnapshotUpdate?: string[];
+  skipped?: Array<{ url?: string; id?: string; reason: string }>;
+  dryRun?: boolean;
+}


### PR DESCRIPTION
## Summary
- Adds `/pending-changes` page that lists KB-freshness proposals the scanner produced for the current tenant.
- Read-only in v1 — list + diff previews only. Approve/reject/apply ships in Phase 3 with the Applier Lambda.
- Backend is the new `GET /proposals` endpoint on Picasso_Config_Manager (see [lambda#9](https://github.com/longhornrumble/lambda/pull/9)).

## What it shows
- Per-tenant list sorted newest-first
- Summary chips (additions / edits / retirements / skipped)
- Per-item cards with classification type + severity chips
- Per-operation preview blocks that mirror the scanner's verbs:
  - `kb.append` / `kb.replace` / `kb.remove`
  - `config.add` / `config.delete` / `config.append_to_array`
  - `dub.upsert`
- Empty-state + refresh button
- Explicit "No tenant selected" fallback

## Files
- `src/types/proposals.ts` — new; Proposal / ProposalItem / Operation types matching the scanner schema
- `src/types/index.ts` — re-export
- `src/lib/api/client.ts` — new `listProposals()` method on `configApiClient`
- `src/pages/PendingChangesPage.tsx` — new page
- `src/pages/index.ts` + `src/App.tsx` — route wiring
- `src/components/layout/Sidebar.tsx` — nav entry (ClipboardList icon, between "Showcase Items" and "Settings")

## Verification
- `tsc --noEmit` adds zero new errors (9 pre-existing errors on main are untouched)
- Page renders end-to-end once the matching Lambda PR deploys

## Related
- Depends on [lambda#9 — GET /proposals endpoint](https://github.com/longhornrumble/lambda/pull/9)
- Phase 1 follow-up: [picasso-webscraping#6 — scanner skip empty proposals](https://github.com/longhornrumble/picasso-webscraping/pull/6)

## Test plan
- [x] Type check (no new errors)
- [ ] Deploy Lambda PR to staging, smoke-test list with MYR384719
- [ ] Visual check in dev server against a real proposal
- [ ] Confirm sidebar nav renders + route resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)