### PR TITLE
fix(deep-link): preserve URL across Clerk sign-in + hash-based tenant resolution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,21 @@ const App: React.FC = () => {
   // Enable auto-save functionality
   useAutoSave();
 
+  // Preserve the intended destination across Clerk sign-in so deep links like
+  // /pending-changes?tenant=MYR384719&proposal=... survive the auth round-trip.
+  //
+  // Clerk defaults post-sign-in navigation to `/` (or ClerkProvider's afterSignInUrl)
+  // unless the SignIn component is given an explicit `forceRedirectUrl`. Reading from
+  // window.location at render time captures whatever the user arrived on. We only set
+  // it when the user is NOT already on `/` — avoids a meaningless self-redirect and
+  // keeps normal sign-in-from-home flows unchanged.
+  const deepLinkRedirectUrl = React.useMemo(() => {
+    if (typeof window === 'undefined') return undefined;
+    const { pathname, search } = window.location;
+    if (pathname === '/' && !search) return undefined;
+    return pathname + search;
+  }, []);
+
   return (
     <>
       {/* Clerk sign-in gate */}
@@ -70,6 +85,8 @@ const App: React.FC = () => {
             <div className="flex justify-center">
               <SignIn
                 routing="hash"
+                forceRedirectUrl={deepLinkRedirectUrl}
+                fallbackRedirectUrl="/"
                 appearance={{
                   elements: {
                     rootBox: 'w-full',

--- a/src/pages/PendingChangesPage.tsx
+++ b/src/pages/PendingChangesPage.tsx
@@ -8,18 +8,53 @@
  * See docs/roadmap/KB_FRESHNESS_LIFECYCLE_SYSTEM.md for schema + context.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ClipboardList, RefreshCw, AlertCircle } from 'lucide-react';
 import { Badge, Button, Spinner, Alert, AlertTitle, AlertDescription } from '@/components/ui';
 import { configApiClient } from '@/lib/api/client';
+import { listTenants } from '@/lib/api';
 import { useConfigStore } from '@/store';
 import type { Proposal, ProposalItem, ProposalOperation } from '@/types/proposals';
 
 export const PendingChangesPage: React.FC = () => {
   const tenantId = useConfigStore((state) => state.config.tenantId);
+  const loadConfig = useConfigStore((state) => state.config.loadConfig);
+  const [searchParams] = useSearchParams();
+  // Deep links from Slack/email MUST carry tenant hash only — never tenant ID.
+  // Per internal security policy: tenant IDs are never exposed in open surfaces
+  // (Slack, email, URLs that could leak). The hash maps 1:1 to a tenant and is
+  // resolved server-side via the tenant list endpoint — no new API surface needed.
+  const deepLinkHash = searchParams.get('h') || undefined;
+  const deepLinkProposal = searchParams.get('proposal') || undefined;
+
   const [proposals, setProposals] = useState<Proposal[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Resolve `?h=HASH` against the tenant list and switch tenant if needed. Runs once
+  // per `deepLinkHash` value — the guard ref prevents re-resolution as the store
+  // settles. Requires the Lambda's `getTenantMetadata` to return `tenant_hash`.
+  const resolvedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!deepLinkHash) return;
+    if (resolvedFor.current === deepLinkHash) return;
+    resolvedFor.current = deepLinkHash;
+
+    listTenants()
+      .then((list) => {
+        const match = (list || []).find((t) => t.tenant_hash === deepLinkHash);
+        if (!match) {
+          setError('Deep link references an unknown tenant hash. Check with whoever shared the link.');
+          return;
+        }
+        if (match.tenantId === tenantId) return;
+        return loadConfig(match.tenantId);
+      })
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : 'Failed to resolve deep-link tenant');
+      });
+  }, [deepLinkHash, tenantId, loadConfig]);
 
   const load = React.useCallback(async () => {
     if (!tenantId) {
@@ -41,6 +76,17 @@ export const PendingChangesPage: React.FC = () => {
   useEffect(() => {
     load();
   }, [load]);
+
+  // After proposals load, scroll the deep-linked proposal into view + highlight it.
+  // The element has id={proposalId}; we rely on the ProposalCard to render that id.
+  // scrollIntoView is feature-detected — JSDOM (tests) doesn't implement it.
+  useEffect(() => {
+    if (!deepLinkProposal || proposals.length === 0) return;
+    const el = document.getElementById(deepLinkProposal);
+    if (el && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [deepLinkProposal, proposals]);
 
   if (!tenantId) {
     return (
@@ -93,7 +139,11 @@ export const PendingChangesPage: React.FC = () => {
 
       <div className="space-y-4">
         {proposals.map((p) => (
-          <ProposalCard key={p.proposalId} proposal={p} />
+          <ProposalCard
+            key={p.proposalId}
+            proposal={p}
+            highlighted={deepLinkProposal === p.proposalId}
+          />
         ))}
       </div>
     </div>
@@ -114,12 +164,21 @@ const PageHeader: React.FC<{ tenantId?: string; count?: number }> = ({ tenantId,
   </div>
 );
 
-const ProposalCard: React.FC<{ proposal: Proposal }> = ({ proposal }) => {
+const ProposalCard: React.FC<{ proposal: Proposal; highlighted?: boolean }> = ({ proposal, highlighted = false }) => {
   const { summary } = proposal;
   const created = new Date(proposal.createdAt).toLocaleString();
 
+  // `id` on the wrapper lets the page's scroll-into-view effect target this card
+  // after a deep-link load. The ring is a visual cue for the linked-to proposal.
   return (
-    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+    <div
+      id={proposal.proposalId}
+      className={`rounded-lg border bg-white dark:bg-gray-800 overflow-hidden transition-shadow ${
+        highlighted
+          ? 'border-teal-500 ring-2 ring-teal-400 shadow-lg'
+          : 'border-gray-200 dark:border-gray-700'
+      }`}
+    >
       <div className="px-5 py-3 bg-teal-50 dark:bg-teal-900/20 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between flex-wrap gap-2">
         <div>
           <div className="font-semibold text-gray-900 dark:text-gray-100">

--- a/src/pages/__tests__/PendingChangesPage.test.tsx
+++ b/src/pages/__tests__/PendingChangesPage.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * PendingChangesPage — deep-link handling
+ *
+ * Security policy: deep links from Slack/email/etc. use the tenant HASH only
+ * (?h=HASH), never the raw tenant ID. The page resolves hash → tenantId by
+ * calling listTenants() and finding a match.
+ *
+ * Covers:
+ *   - ?h=HASH matches a listed tenant with matching tenantId → no loadConfig
+ *     call (already selected)
+ *   - ?h=HASH matches a listed tenant with different tenantId → loadConfig fires
+ *   - ?h=HASH doesn't match any tenant → error banner
+ *   - listTenants() fails → error banner
+ *   - ?proposal=ID with matching proposal → card has id attribute + highlight
+ *   - No deep-link params → page renders normally, no listTenants call
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Mocks — store, API client, listTenants
+// ---------------------------------------------------------------------------
+
+const mockLoadConfig = vi.fn();
+
+let storeState: { config: { tenantId: string | null; loadConfig: typeof mockLoadConfig } } = {
+  config: { tenantId: 'CURRENT_TENANT', loadConfig: mockLoadConfig },
+};
+
+vi.mock('@/store', () => ({
+  useConfigStore: (selector: (s: typeof storeState) => unknown) => selector(storeState),
+}));
+
+const mockListProposals = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  configApiClient: {
+    listProposals: (...args: unknown[]) => mockListProposals(...args),
+  },
+}));
+
+const mockListTenants = vi.fn();
+vi.mock('@/lib/api', () => ({
+  listTenants: (...args: unknown[]) => mockListTenants(...args),
+}));
+
+// Shared proposal fixture so scroll/highlight assertions can target its id.
+const proposalFixture = {
+  proposalId: 'MYR384719-20260501-abcd',
+  tenantId: 'MYR384719',
+  createdAt: '2026-05-01T12:00:00Z',
+  status: 'pending' as const,
+  siteUrl: 'https://www.atlantaangels.org',
+  summary: { additions: 2, edits: 1, retirements: 0 },
+  items: [],
+};
+
+const tenantListFixture = [
+  { tenantId: 'CURRENT_TENANT', tenant_hash: 'cu12345abcde', company_name: 'Current Co.' },
+  { tenantId: 'OTHER_TENANT', tenant_hash: 'ot67890fghij', company_name: 'Other Co.' },
+];
+
+import { PendingChangesPage } from '../PendingChangesPage';
+
+function renderWithRouter(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <PendingChangesPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockLoadConfig.mockReset();
+  mockLoadConfig.mockResolvedValue(undefined);
+  mockListProposals.mockReset();
+  mockListProposals.mockResolvedValue([]);
+  mockListTenants.mockReset();
+  mockListTenants.mockResolvedValue(tenantListFixture);
+  storeState = {
+    config: { tenantId: 'CURRENT_TENANT', loadConfig: mockLoadConfig },
+  };
+});
+
+describe('PendingChangesPage — deep-link handling (hash-based, per security policy)', () => {
+  it('no deep-link params → no listTenants call, no loadConfig call', async () => {
+    renderWithRouter('/pending-changes');
+    await waitFor(() => expect(mockListProposals).toHaveBeenCalled());
+    expect(mockListTenants).not.toHaveBeenCalled();
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+  });
+
+  it('?h=HASH resolves to current tenant → listTenants called, but no loadConfig', async () => {
+    renderWithRouter('/pending-changes?h=cu12345abcde');
+    await waitFor(() => expect(mockListTenants).toHaveBeenCalled());
+    // Give React a tick for the .then branch to run — it decides NOT to loadConfig.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+  });
+
+  it('?h=HASH resolves to a different tenant → loadConfig fires with the resolved ID', async () => {
+    renderWithRouter('/pending-changes?h=ot67890fghij');
+    await waitFor(() => {
+      expect(mockLoadConfig).toHaveBeenCalledTimes(1);
+      expect(mockLoadConfig).toHaveBeenCalledWith('OTHER_TENANT');
+    });
+  });
+
+  it('?h=HASH with no matching tenant → error banner shown, no loadConfig', async () => {
+    renderWithRouter('/pending-changes?h=unknownhashvalue');
+    await waitFor(() => {
+      expect(screen.getByText(/unknown tenant hash/i)).toBeTruthy();
+    });
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+  });
+
+  it('listTenants() itself fails → error banner surfaces the message', async () => {
+    mockListTenants.mockRejectedValueOnce(new Error('Network down'));
+    renderWithRouter('/pending-changes?h=cu12345abcde');
+    await waitFor(() => {
+      expect(screen.getByText(/Network down/)).toBeTruthy();
+    });
+  });
+
+  it('?proposal=ID + matching card → card has id attribute + highlighted ring', async () => {
+    mockListProposals.mockResolvedValueOnce([proposalFixture]);
+    const { container } = renderWithRouter(
+      `/pending-changes?proposal=${proposalFixture.proposalId}`,
+    );
+    await waitFor(() => {
+      const card = container.querySelector(`#${CSS.escape(proposalFixture.proposalId)}`);
+      expect(card).toBeTruthy();
+      expect(card?.className).toContain('ring-2');
+      expect(card?.className).toContain('border-teal-500');
+    });
+  });
+
+  it('?proposal=ID with no matching card → card absent, no error, no highlight', async () => {
+    mockListProposals.mockResolvedValueOnce([proposalFixture]);
+    const { container } = renderWithRouter('/pending-changes?proposal=NONEXISTENT-PROPOSAL-ID');
+    await waitFor(() => expect(mockListProposals).toHaveBeenCalled());
+    const card = container.querySelector(`#${CSS.escape(proposalFixture.proposalId)}`);
+    expect(card).toBeTruthy();
+    expect(card?.className).not.toContain('ring-2');
+  });
+});

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -27,6 +27,13 @@ export interface TenantListItem {
   lastModified: number;
   version: string;
   tier: string;
+  /**
+   * Tenant hash — emitted by Picasso_Config_Manager's getTenantMetadata.
+   * Used to resolve hash-based deep links (e.g. /pending-changes?h=HASH) without
+   * putting raw tenant IDs in open surfaces like Slack messages and email bodies.
+   * May be null/undefined for older configs that pre-date the metadata addition.
+   */
+  tenant_hash?: string | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Two related fixes for the Slack/email "Review Changes" deep link that lands on `/pending-changes`.

### 1. Clerk sign-in preserves the intended URL

`App.tsx`: pass `forceRedirectUrl={pathname+search}` to `<SignIn>` when the user arrives on a non-root URL. Clerk's default post-auth navigation drops the deep link; the override preserves it. Normal sign-in-from-home flow is unchanged.

### 2. Hash-based deep-link resolution on PendingChangesPage

Per internal security policy, tenant IDs must never appear in open surfaces (Slack, email, URLs that could leak). Deep links carry only the tenant **hash** (`?h=HASH`). The page:

- Reads `?h=HASH` → calls `listTenants()` → finds entry where `tenant_hash === HASH` → calls `loadConfig(tenantId)`
- Reads `?proposal=ID` → scrolls the matching proposal card into view + adds a highlight ring (`scrollIntoView` feature-detected for JSDOM compatibility)
- Handles: hash matches current tenant (no-op), hash matches other tenant (switch), hash unknown (error banner), `listTenants()` failure (error banner)

### Depends on

- [lambda#12](https://github.com/longhornrumble/lambda/pull/12) — `tenant_hash` in `getTenantMetadata` response (frontend reads it here)
- [picasso-webscraping#9](https://github.com/longhornrumble/picasso-webscraping/pull/9) — notifier workflow builds `?h=HASH` URLs

## Tests

7 new Vitest tests in `src/pages/__tests__/PendingChangesPage.test.tsx`:

| # | Scenario | Asserts |
|---|---|---|
| 1 | No deep-link params | No `listTenants`, no `loadConfig` call |
| 2 | `?h=HASH` matches current tenant | `listTenants` called, no `loadConfig` |
| 3 | `?h=HASH` matches different tenant | `loadConfig(resolvedId)` fires once |
| 4 | `?h=HASH` matches no tenant | Error banner: "unknown tenant hash" |
| 5 | `listTenants()` rejects | Error banner surfaces the message |
| 6 | `?proposal=ID` matching card | Card has `id` attribute + `ring-2` / `border-teal-500` |
| 7 | `?proposal=ID` no match | Card renders normally, no highlight |

All 7 pass locally. Typecheck clean on touched files.

## Test plan

- [x] Unit tests (7/7)
- [ ] CI green
- [ ] Lambda#12 merged + deployed
- [ ] Webscraping#9 merged + live workflow swapped
- [ ] Config-builder deployed to staging
- [ ] End-to-end: sign out → click Slack "Review Changes" link → land on Pending Changes with correct tenant loaded + correct proposal highlighted
- [ ] Clerk dashboard: add `https://picasso-config-builder-prod.s3-website-us-east-1.amazonaws.com/*` to allowed redirect URLs (user action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)