### PR TITLE
hotfix: wire VITE_CHANNELS_API_URL through esbuild define

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -128,6 +128,7 @@ const defineVars = {
   'import.meta.env.VITE_AWS_REGION': JSON.stringify(process.env.VITE_AWS_REGION || 'us-east-1'),
   'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || ''),
   'import.meta.env.VITE_CLERK_PUBLISHABLE_KEY': JSON.stringify(process.env.VITE_CLERK_PUBLISHABLE_KEY || ''),
+  'import.meta.env.VITE_CHANNELS_API_URL': JSON.stringify(process.env.VITE_CHANNELS_API_URL || ''),
 
   // Node.js environment compatibility
   'process.env.NODE_ENV': JSON.stringify(isDevelopment ? 'development' : 'production')

--- a/src/components/settings/ChannelsSettings.tsx
+++ b/src/components/settings/ChannelsSettings.tsx
@@ -25,7 +25,10 @@ import type { ChannelConnection, ChannelsConfig } from '@/types/config';
 // Constants
 // ---------------------------------------------------------------------------
 
-const CHANNELS_API_URL = import.meta.env.VITE_CHANNELS_API_URL || 'https://qwxscz5w6lkzjmhcpyhewijize0jpzzx.lambda-url.us-east-1.on.aws';
+// `import.meta.env` can be undefined under ESBuild's dev pipeline (unlike Vite's
+// auto-injection), which crashed module load and blocked the whole app from
+// rendering. Guard against it so the fallback URL is always reachable.
+const CHANNELS_API_URL = (typeof import.meta !== 'undefined' && import.meta.env?.VITE_CHANNELS_API_URL) || 'https://qwxscz5w6lkzjmhcpyhewijize0jpzzx.lambda-url.us-east-1.on.aws';
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

Fixes an app-wide crash at module load.

`ChannelsSettings.tsx` reads `import.meta.env.VITE_CHANNELS_API_URL` at module scope, but the key was never added to `esbuild.config.mjs`'s `define` block. In dev (and any build where `VITE_CHANNELS_API_URL` isn't set on the runner), esbuild left the expression unreplaced — a live runtime read against a non-existent object — which threw `TypeError: Cannot read properties of undefined (reading 'VITE_CHANNELS_API_URL')` at module load.

**Blast radius:** all routes, not just `/settings`. `ChannelsSettings` is eagerly imported via the pages barrel, so the module-load crash blocked the entire app from rendering. Discovered today when testing a deep link: the app returned HTTP 200 but rendered nothing.

## Fix (dual-layer)

1. **esbuild.config.mjs** — add the missing define entry, matching the pattern all other `VITE_*` vars already use.
2. **ChannelsSettings.tsx** — optional-chain the access as defense-in-depth, so future env vars added without updating esbuild config degrade to the fallback URL instead of crashing.

## Tests

- 29/29 existing `ChannelsSettings.test.tsx` tests pass unchanged
- Verified live in dev: app renders, `/pending-changes?h=HASH` deep-link flow completes end-to-end (sign-in preserves URL, hash resolves to correct tenant, tenant switches correctly)

## Production context

Prod may not have been crashing if `VITE_CHANNELS_API_URL` was somehow present on the prod build runner's env — but the define gap meant any new dev setup or any missing env var would bring the app down. This closes the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)