### PR TITLE
fix(deploy-button): hide 'Deploy' text below lg breakpoint (mobile overflow)

### DIFF
--- a/src/components/deploy/DeployButton.tsx
+++ b/src/components/deploy/DeployButton.tsx
@@ -141,8 +141,8 @@ export const DeployButton: React.FC<DeployButtonProps> = ({ className = '' }) =>
               }
             `}
           >
-            <Upload className="w-4 h-4 mr-2" />
-            Deploy
+            <Upload className="w-4 h-4 lg:mr-2" />
+            <span className="hidden lg:inline">Deploy</span>
             {isDirty && !isDeployDisabled && (
               <span className="ml-2 w-2 h-2 bg-amber-400 rounded-full" title="Unsaved changes" />
             )}


### PR DESCRIPTION
## Summary

One-line CSS fix for mobile header overflow.

On mobile viewports the header bar overflowed horizontally because `DeployButton` rendered both the Upload icon AND the "Deploy" label at all widths — truncating as `"Dep..."` off the right edge on an iPhone 12 Pro.

## Fix

Matches the responsive pattern already used by Preview and Save buttons:

```diff
- <Upload className="w-4 h-4 mr-2" />
- Deploy
+ <Upload className="w-4 h-4 lg:mr-2" />
+ <span className="hidden lg:inline">Deploy</span>
```

Icon stays visible at all widths so the button is still identifiable and tappable.

## Context

Surfaced during mobile verification of the passwordless deep-link flow ([#17](https://github.com/longhornrumble/picasso-config-builder/pull/17)). User reported the rest of Pending Changes renders correctly on mobile — proposal cards, empty state, Refresh button all fine. Only the header bar was broken.

## Test plan

- [x] Typecheck clean
- [x] No existing DeployButton tests to regress
- [ ] Post-deploy: verify on iPhone 12 Pro (real device) OR Chrome DevTools iPhone emulation that the header fits without horizontal scroll
- [ ] Below lg (1024px): icon-only; at lg and above: icon + "Deploy" text (unchanged from prior desktop behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)