### PR TITLE
feat(scheduling): extend cta.schema.ts action/type enums for scheduling triggers (A4)

### DIFF
--- a/src/lib/schemas/__tests__/cta.schema.test.ts
+++ b/src/lib/schemas/__tests__/cta.schema.test.ts
@@ -1,0 +1,126 @@
+/**
+ * cta.schema.ts tests — focused on scheduling action/type extensions (sub-phase A4).
+ *
+ * Spec source: scheduling/docs/scheduling_config_schema.md §3.
+ * Cross-config invariants (scheduling_enabled + non-empty appointment_types) live
+ * in tenant.schema.ts and are covered separately in sub-phase A5.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ctaDefinitionSchema } from '../cta.schema';
+
+const baseCta = {
+  label: 'Schedule a call',
+};
+
+describe('ctaDefinitionSchema — scheduling actions (A4)', () => {
+  it('accepts start_scheduling paired with scheduling_trigger', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        ...baseCta,
+        action: 'start_scheduling',
+        type: 'scheduling_trigger',
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts resume_scheduling paired with scheduling_trigger', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        ...baseCta,
+        label: 'Resume your booking',
+        action: 'resume_scheduling',
+        type: 'scheduling_trigger',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects start_scheduling paired with a non-scheduling type', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        ...baseCta,
+        action: 'start_scheduling',
+        type: 'form_trigger',
+      }),
+    ).toThrow(/does not match action.*start_scheduling/);
+  });
+
+  it('rejects scheduling_trigger paired with a non-scheduling action', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        ...baseCta,
+        action: 'start_form',
+        type: 'scheduling_trigger',
+        formId: 'volunteer_apply',
+      }),
+    ).toThrow(/does not match action.*start_form/);
+  });
+
+  it('does not require formId / url / query / prompt for scheduling actions', () => {
+    const parsed = ctaDefinitionSchema.parse({
+      ...baseCta,
+      action: 'start_scheduling',
+      type: 'scheduling_trigger',
+    });
+    expect(parsed.formId).toBeUndefined();
+    expect(parsed.url).toBeUndefined();
+    expect(parsed.query).toBeUndefined();
+    expect(parsed.prompt).toBeUndefined();
+  });
+
+  it('still rejects unknown action values', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        ...baseCta,
+        action: 'totally_unknown',
+        type: 'scheduling_trigger',
+      }),
+    ).toThrow(/Invalid action type/);
+  });
+});
+
+describe('ctaDefinitionSchema — pre-existing actions remain valid', () => {
+  it('still accepts start_form + form_trigger with formId', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        label: 'Apply Now',
+        action: 'start_form',
+        type: 'form_trigger',
+        formId: 'volunteer_apply',
+      }),
+    ).not.toThrow();
+  });
+
+  it('still accepts external_link + external_link with url', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        label: 'Visit Site',
+        action: 'external_link',
+        type: 'external_link',
+        url: 'https://example.com',
+      }),
+    ).not.toThrow();
+  });
+
+  it('still accepts send_query + bedrock_query with query', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        label: 'Tell me more',
+        action: 'send_query',
+        type: 'bedrock_query',
+        query: 'Tell me about your programs',
+      }),
+    ).not.toThrow();
+  });
+
+  it('still accepts show_info + info_request with prompt', () => {
+    expect(() =>
+      ctaDefinitionSchema.parse({
+        label: 'Learn More',
+        action: 'show_info',
+        type: 'info_request',
+        prompt: 'Show information about volunteering',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/lib/schemas/cta.schema.ts
+++ b/src/lib/schemas/cta.schema.ts
@@ -11,16 +11,22 @@ import { z } from 'zod';
 export const ctaDefinitionSchema = z.object({
   text: z.string().max(100, 'Legacy text field must be 100 characters or less').optional(),
   label: z.string().min(1, 'Label is required').max(100, 'Label must be 100 characters or less'),
-  action: z.enum(['start_form', 'external_link', 'send_query', 'show_info'], {
-    errorMap: () => ({ message: 'Invalid action type' }),
-  }),
+  action: z.enum(
+    ['start_form', 'external_link', 'send_query', 'show_info', 'start_scheduling', 'resume_scheduling'],
+    {
+      errorMap: () => ({ message: 'Invalid action type' }),
+    }
+  ),
   formId: z.string().optional(),
   url: z.string().url('Must be a valid URL').optional(),
   query: z.string().optional(), // No max length - supports paragraphs
   prompt: z.string().optional(), // No max length - supports paragraphs
-  type: z.enum(['form_trigger', 'external_link', 'bedrock_query', 'info_request'], {
-    errorMap: () => ({ message: 'Invalid CTA type' }),
-  }),
+  type: z.enum(
+    ['form_trigger', 'external_link', 'bedrock_query', 'info_request', 'scheduling_trigger'],
+    {
+      errorMap: () => ({ message: 'Invalid CTA type' }),
+    }
+  ),
   target_branch: z
     .string()
     .min(1, 'Target branch ID cannot be empty')
@@ -90,6 +96,8 @@ export const ctaDefinitionSchema = z.object({
     external_link: 'external_link',
     send_query: 'bedrock_query',
     show_info: 'info_request',
+    start_scheduling: 'scheduling_trigger',
+    resume_scheduling: 'scheduling_trigger',
   };
 
   const expectedType = typeActionMap[data.action];


### PR DESCRIPTION
## Summary
Sub-phase A4 of the [scheduling v1 implementation plan](../../scheduling/docs/scheduling_implementation_plan.md). Extends `ctaDefinitionSchema` so the Config Builder accepts `start_scheduling` / `resume_scheduling` CTAs without validation errors.

- `action` enum gains `start_scheduling`, `resume_scheduling`
- `type` enum gains `scheduling_trigger`
- `typeActionMap` pairs both new actions with `scheduling_trigger`

Scheduling CTAs do not require `formId`, `url`, `query`, or `prompt` — they reference scheduling indirectly via the active scheduling config. Cross-config invariants (`scheduling_enabled === true`, non-empty `appointment_types`) live in `tenant.schema.ts` and are covered in sub-phase A5.

Spec: `scheduling/docs/scheduling_config_schema.md` §3.

## Test plan
- [x] New `cta.schema.test.ts` (10 tests, all passing locally)
  - Accepts both new action/type pairings
  - Rejects mismatched action/type combinations
  - Confirms scheduling actions don't require auxiliary fields
  - Pre-existing actions remain valid
- [x] Full schema test suite green (30/30 passing across cta + scheduling)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)