### PR TITLE
ci: promote typecheck to required gate

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,10 +39,8 @@ jobs:
         run: npm run lint
 
   typecheck:
-    # See pr-checks.yml — typecheck deferred until PR #24 (draft feature) lands.
     name: Code Quality - Type Checking
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -125,7 +123,7 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: [test, security, build]
+    needs: [typecheck, test, security, build]
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,13 +35,8 @@ jobs:
         run: npm run lint
 
   typecheck:
-    # TODO(draft-feature): Flip continue-on-error to false once PR #24
-    # (feat/draft-autosave) lands. The draft slice references
-    # configApiClient.loadDraft/saveDraft/deleteDraft methods that don't
-    # exist on the type yet — PR #24 adds them.
     name: Code Quality - Type Checking
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- PR #24 merged the draft feature to main, adding the missing ConfigAPIClient methods
- \`npm run typecheck\` is now clean on main
- Drops \`continue-on-error: true\` from the typecheck job in both workflows
- Adds \`typecheck\` to \`deploy-production\` job's \`needs:\` chain

## Follow-up

After this merges, branch protection on \`main\` will be updated to include \`Code Quality - Type Checking\` as a required status check.

Lint remains \`continue-on-error: true\` pending the lint cleanup PR.

## Test plan

- [x] \`npm run typecheck\` clean locally on fresh main
- [ ] CI passes on this PR (typecheck now blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)