### PR TITLE
chore(lint): Phase A — mechanical lint cleanup (-45 violations)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage', 'lambda/node_modules']),
+  globalIgnores(['dist', 'coverage', 'lambda/node_modules', 'src/examples']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -16,6 +16,12 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
     },
   },
 ])

--- a/src/__tests__/integration/errorHandling.test.tsx
+++ b/src/__tests__/integration/errorHandling.test.tsx
@@ -178,12 +178,12 @@ describe('Error Handling Integration Tests', () => {
     expect(result.current.validation.isValid).toBe(false);
 
     // Attempt to deploy
-    let error: Error | null = null;
+    let _error: Error | null = null;
     await act(async () => {
       try {
         await result.current.config.deployConfig();
       } catch (e) {
-        error = e as Error;
+        _error = e as Error;
       }
     });
 
@@ -272,12 +272,12 @@ describe('Error Handling Integration Tests', () => {
     );
 
     // Attempt to load
-    let error: Error | null = null;
+    let _error: Error | null = null;
     await act(async () => {
       try {
         await result.current.config.loadConfig('TEST_TENANT');
       } catch (e) {
-        error = e as Error;
+        _error = e as Error;
       }
     });
 

--- a/src/__tests__/integration/formCreationWorkflow.test.tsx
+++ b/src/__tests__/integration/formCreationWorkflow.test.tsx
@@ -20,10 +20,7 @@ import {
   createTestFormField,
   resetIdCounter,
   extractValidationErrors,
-  extractValidationWarnings,
-  getEntityErrors,
   getEntityWarnings,
-  getValidationSummary,
   resetConfigStore,
 } from './testUtils';
 import type { FormField } from '@/types/config';

--- a/src/__tests__/integration/validationPipeline.test.tsx
+++ b/src/__tests__/integration/validationPipeline.test.tsx
@@ -17,7 +17,6 @@ import {
   createTestForm,
   resetIdCounter,
   extractValidationErrors,
-  extractValidationWarnings,
   getEntityErrors,
   getEntityWarnings,
   getValidationSummary,

--- a/src/components/dashboard/__tests__/ConversationFlowDiagram.test.tsx
+++ b/src/components/dashboard/__tests__/ConversationFlowDiagram.test.tsx
@@ -844,7 +844,7 @@ describe('ConversationFlowDiagram', () => {
 
         // Should show "...and 5 more" (max 10 displayed)
         await waitFor(() => {
-          const moreText = screen.queryByText(/...and 5 more/);
+          const _moreText = screen.queryByText(/...and 5 more/);
           // This is implementation-dependent, may need adjustment
         });
       }

--- a/src/components/layout/DraftBanner.tsx
+++ b/src/components/layout/DraftBanner.tsx
@@ -89,7 +89,6 @@ export const DraftBanner: React.FC = () => {
             onClick={handleResume}
             disabled={isLoadingDraft || isDiscarding}
             className="border-amber-500 text-amber-300 hover:bg-amber-900/40 text-xs"
-            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
           >
             {isLoadingDraft ? 'Resuming...' : 'Resume Draft'}

--- a/src/components/settings/__tests__/ChannelsSettings.test.tsx
+++ b/src/components/settings/__tests__/ChannelsSettings.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // ---------------------------------------------------------------------------

--- a/src/lib/api/localDevServer.ts
+++ b/src/lib/api/localDevServer.ts
@@ -216,13 +216,13 @@ app.get('/config/:tenantId', async (req, res) => {
       const editableConfig: Record<string, unknown> = {};
 
       METADATA_FIELDS.forEach(field => {
-        if (config.hasOwnProperty(field)) {
+        if (Object.prototype.hasOwnProperty.call(config, field)) {
           editableConfig[field] = config[field];
         }
       });
 
       EDITABLE_SECTIONS.forEach(section => {
-        if (config.hasOwnProperty(section)) {
+        if (Object.prototype.hasOwnProperty.call(config, section)) {
           editableConfig[section] = config[section];
         }
       });

--- a/src/lib/api/localDevServerS3.ts
+++ b/src/lib/api/localDevServerS3.ts
@@ -247,13 +247,13 @@ app.get('/config/:tenantId', async (req, res) => {
       const editableConfig: Record<string, unknown> = {};
 
       METADATA_FIELDS.forEach(field => {
-        if (config.hasOwnProperty(field)) {
+        if (Object.prototype.hasOwnProperty.call(config, field)) {
           editableConfig[field] = config[field];
         }
       });
 
       EDITABLE_SECTIONS.forEach(section => {
-        if (config.hasOwnProperty(section)) {
+        if (Object.prototype.hasOwnProperty.call(config, section)) {
           editableConfig[section] = config[section];
         }
       });
@@ -340,7 +340,7 @@ app.put('/config/:tenantId', async (req, res) => {
           finalConfig = { ...baseConfig, ...editedConfig };
           finalConfig.tenant_id = tenantId;
         }
-      } catch (error) {
+      } catch {
         console.log('Creating new config (no existing config found)');
       }
     }

--- a/src/lib/schemas/__tests__/scheduling.schema.test.ts
+++ b/src/lib/schemas/__tests__/scheduling.schema.test.ts
@@ -131,7 +131,7 @@ describe('appointmentTypeSchema', () => {
   });
 
   it('requires routing_policy_id', () => {
-    const { routing_policy_id, ...without } = validAppointmentType;
+    const { routing_policy_id: _routing_policy_id, ...without } = validAppointmentType;
     expect(() => appointmentTypeSchema.parse(without)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Phase A of the ESLint debt cleanup. Knocks out three rule categories with zero behavioral risk, dropping the lint baseline from **233 problems (226 errors + 7 warnings)** to **188 (181 errors + 7 warnings)**.

Follow-up to #26 which landed the ESLint 9 flat config.

## Changes

### 1. `no-prototype-builtins` (-4)
- 4× `obj.hasOwnProperty(k)` → `Object.prototype.hasOwnProperty.call(obj, k)` in `localDevServer.ts` and `localDevServerS3.ts`.
- Used `.call()` form (not `Object.hasOwn`) to stay within the project's ES2020 `lib` target — `Object.hasOwn` would have required bumping to ES2022.

### 2. `jsx-a11y/no-autofocus` (-1)
- Removed 1 stale `// eslint-disable-next-line jsx-a11y/no-autofocus` directive in `DraftBanner.tsx`. The `eslint-plugin-jsx-a11y` plugin isn't installed, so the directive was flagged as "rule not found" under `--report-unused-disable-directives`.
- The `autoFocus` prop is unchanged — the rule was never enforced anyway.

### 3. `no-unused-vars` (-39)
**3a. Added `_`-prefix exemption to the rule** (`argsIgnorePattern`, `varsIgnorePattern`, `caughtErrorsIgnorePattern`: `'^_'`). The codebase already uses this convention (`_signOut`, `_branchId`, `_form`, etc.) — but `tseslint.configs.recommended`'s default for the rule doesn't exempt it. This single config change silenced 18 of the 39 violations.

**3b. Real unused-var cleanup (21):**
- Deleted unused imports in test files: `extractValidationWarnings`, `getEntityErrors`, `getValidationSummary`, `within`
- Renamed unused capture vars to `_`-prefix: `let _error` (errorHandling.test.tsx ×2), `const _moreText`, destructure-rename `{ routing_policy_id: _routing_policy_id, ...without }`
- Converted unused catch binding to bare `catch` in `localDevServerS3.ts`

**3c. Added `src/examples` to `globalIgnores`:**
The 3 files in `src/examples/` (`StoreUsageExamples`, `ConfigUsageExamples`, `UIComponentExamples`) demonstrate store API patterns. They're not imported anywhere in the project and don't ship to production. Per the original cleanup plan: "dev-only files... consider whether they should be added to globalIgnores instead of fixed." Doing that here.

## Verification

- [x] `npm run lint`: 233 → 188 problems (Phase A categories all at zero)
- [x] `npm run typecheck`: clean (initially failed on `Object.hasOwn` — switched to `.call()` form to avoid lib bump)
- [x] `npm run test:run`: 437/437 passing
- [x] All changes are semantics-preserving — no logic touched. The existing 437-test suite is the verification surface.

## Remaining lint debt

| Phase | Rules | Count |
|---|---|---|
| B | `react-hooks/*` correctness | ~40 |
| C | `@typescript-eslint/no-explicit-any` | 148 |
| | _Total remaining_ | **188** |

Phase B and C will land as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)