### PR TITLE
chore(lint): Phase B2 — react-hooks correctness fixes (-10 violations)

### DIFF
--- a/src/components/editors/FormsEditor/FieldCollection.tsx
+++ b/src/components/editors/FormsEditor/FieldCollection.tsx
@@ -9,6 +9,12 @@ import { Plus, AlertCircle } from 'lucide-react';
 import { FieldEditor } from './FieldEditor';
 import type { FormField } from '@/types/config';
 
+// Module-scope ID generators — keeps the impure Date.now() call outside the
+// component body so react-hooks/purity is satisfied. Both run only in click
+// handlers (post-render), but the rule flags Date.now() syntactically.
+const newFieldId = () => `field_${Date.now()}`;
+const duplicateFieldId = (originalId: string) => `${originalId}_copy_${Date.now()}`;
+
 export interface FieldCollectionProps {
   fields: FormField[];
   onChange: (fields: FormField[]) => void;
@@ -26,7 +32,7 @@ export const FieldCollection: React.FC<FieldCollectionProps> = ({
 }) => {
   const handleAddField = () => {
     const newField: FormField = {
-      id: `field_${Date.now()}`,
+      id: newFieldId(),
       type: 'text',
       label: '',
       prompt: '',
@@ -52,7 +58,7 @@ export const FieldCollection: React.FC<FieldCollectionProps> = ({
     const fieldToDuplicate = fields[index];
     const duplicatedField: FormField = {
       ...fieldToDuplicate,
-      id: `${fieldToDuplicate.id}_copy_${Date.now()}`,
+      id: duplicateFieldId(fieldToDuplicate.id),
       label: `${fieldToDuplicate.label} (Copy)`,
     };
     const newFields = [...fields];

--- a/src/components/editors/ProgramsEditor/ProgramForm.tsx
+++ b/src/components/editors/ProgramsEditor/ProgramForm.tsx
@@ -104,7 +104,9 @@ export const ProgramForm: React.FC<ProgramFormProps> = ({
     }
   }, [program, open]);
 
-  // Validate form data
+  // Validate form data — current program id extracted to local so the
+  // useCallback dep array is statically analyzable (preserves manual memo)
+  const currentProgramId = program?.program_id;
   const validate = useCallback(
     (data: FormData): FormErrors => {
       const newErrors: FormErrors = {};
@@ -119,7 +121,7 @@ export const ProgramForm: React.FC<ProgramFormProps> = ({
 
         // Check for duplicate program_id (only in create mode or if ID changed)
         if (
-          (!isEditMode || data.program_id !== program?.program_id) &&
+          (!isEditMode || data.program_id !== currentProgramId) &&
           existingProgramIds.includes(data.program_id)
         ) {
           newErrors.program_id = 'A program with this ID already exists';
@@ -137,7 +139,7 @@ export const ProgramForm: React.FC<ProgramFormProps> = ({
 
       return newErrors;
     },
-    [isEditMode, program?.program_id, existingProgramIds]
+    [isEditMode, currentProgramId, existingProgramIds]
   );
 
   // Handle field changes

--- a/src/components/modals/CreateTenantModal.tsx
+++ b/src/components/modals/CreateTenantModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Copy, Check, Loader2, Plus } from 'lucide-react';
 import {
@@ -48,7 +48,7 @@ export const CreateTenantModal: React.FC<CreateTenantModalProps> = ({ open, onCl
     handleSubmit,
     formState: { errors },
     reset,
-    watch,
+    control,
     setValue,
   } = useForm<CreateTenantFormData>({
     resolver: zodResolver(createTenantSchema),
@@ -64,7 +64,8 @@ export const CreateTenantModal: React.FC<CreateTenantModalProps> = ({ open, onCl
     },
   });
 
-  const primaryColor = watch('primary_color');
+  const primaryColor = useWatch({ control, name: 'primary_color' });
+  const subscriptionTier = useWatch({ control, name: 'subscription_tier' });
 
   const handleClose = () => {
     reset();
@@ -184,7 +185,7 @@ export const CreateTenantModal: React.FC<CreateTenantModalProps> = ({ open, onCl
                 { value: 'Standard', label: 'Standard' },
                 { value: 'Premium', label: 'Premium' },
               ]}
-              value={watch('subscription_tier')}
+              value={subscriptionTier}
               onValueChange={(value) => setValue('subscription_tier', value as any)}
               error={errors.subscription_tier?.message}
             />

--- a/src/hooks/crud/useEntityCRUD.ts
+++ b/src/hooks/crud/useEntityCRUD.ts
@@ -104,7 +104,7 @@ export function useEntityCRUD<T extends BaseEntity>(
   const openEditModal = useCallback((entity: T) => {
     setEditingEntity(entity);
     setIsFormOpen(true);
-  }, [getId]);
+  }, []);
 
   // Open delete modal
   const openDeleteModal = useCallback((entity: T) => {

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -4,7 +4,7 @@
  * Recovers unsaved work on page reload
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useConfigStore } from '@/store';
 
 export interface AutoSaveOptions {
@@ -46,7 +46,7 @@ const DEFAULT_OPTIONS: Required<AutoSaveOptions> = {
  * ```
  */
 export function useAutoSave(options: AutoSaveOptions = {}) {
-  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const { debounceMs, enabled, storageKey } = { ...DEFAULT_OPTIONS, ...options };
 
   const tenantId = useConfigStore((state) => state.config.tenantId);
   const isDirty = useConfigStore((state) => state.config.isDirty);
@@ -62,8 +62,8 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
   /**
    * Save current state to sessionStorage
    */
-  const saveToStorage = () => {
-    if (!tenantId || !isDirty || !opts.enabled) {
+  const saveToStorage = useCallback(() => {
+    if (!tenantId || !isDirty || !enabled) {
       return;
     }
 
@@ -78,7 +78,7 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
         contentShowcase,
       };
 
-      const key = `${opts.storageKey}-${tenantId}`;
+      const key = `${storageKey}-${tenantId}`;
       sessionStorage.setItem(key, JSON.stringify(autoSaveData));
       lastSaveRef.current = Date.now();
 
@@ -86,18 +86,18 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
     } catch (error) {
       console.error('Failed to auto-save:', error);
     }
-  };
+  }, [tenantId, isDirty, enabled, programs, forms, ctas, branches, contentShowcase, storageKey]);
 
   /**
    * Load saved state from sessionStorage
    */
-  const loadFromStorage = () => {
-    if (!tenantId || !opts.enabled) {
+  const loadFromStorage = useCallback(() => {
+    if (!tenantId || !enabled) {
       return false;
     }
 
     try {
-      const key = `${opts.storageKey}-${tenantId}`;
+      const key = `${storageKey}-${tenantId}`;
       const saved = sessionStorage.getItem(key);
 
       if (!saved) {
@@ -146,39 +146,39 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
       console.error('Failed to load autosave:', error);
       return false;
     }
-  };
+  }, [tenantId, enabled, storageKey]);
 
   /**
    * Clear autosave for current tenant
    */
-  const clearAutoSave = () => {
+  const clearAutoSave = useCallback(() => {
     if (!tenantId) {
       return;
     }
 
     try {
-      const key = `${opts.storageKey}-${tenantId}`;
+      const key = `${storageKey}-${tenantId}`;
       sessionStorage.removeItem(key);
       console.log('Cleared autosave for:', tenantId);
     } catch (error) {
       console.error('Failed to clear autosave:', error);
     }
-  };
+  }, [tenantId, storageKey]);
 
   /**
    * Load autosave on mount (when tenant changes)
    */
   useEffect(() => {
-    if (tenantId && opts.enabled) {
+    if (tenantId && enabled) {
       loadFromStorage();
     }
-  }, [tenantId]); // Only run when tenant changes
+  }, [tenantId, enabled, loadFromStorage]);
 
   /**
    * Set up debounced auto-save
    */
   useEffect(() => {
-    if (!opts.enabled || !isDirty || !tenantId) {
+    if (!enabled || !isDirty || !tenantId) {
       return;
     }
 
@@ -190,7 +190,7 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
     // Set up new timer
     saveTimerRef.current = setTimeout(() => {
       saveToStorage();
-    }, opts.debounceMs);
+    }, debounceMs);
 
     // Cleanup on unmount or deps change
     return () => {
@@ -198,7 +198,7 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
         clearTimeout(saveTimerRef.current);
       }
     };
-  }, [programs, forms, ctas, branches, contentShowcase, isDirty, tenantId, opts.enabled, opts.debounceMs]);
+  }, [isDirty, tenantId, enabled, debounceMs, saveToStorage]);
 
   /**
    * Clear autosave when config is no longer dirty (after successful save/deploy)
@@ -207,13 +207,13 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
     if (!isDirty && tenantId) {
       clearAutoSave();
     }
-  }, [isDirty, tenantId]);
+  }, [isDirty, tenantId, clearAutoSave]);
 
   /**
    * Save immediately before page unload if there are unsaved changes
    */
   useEffect(() => {
-    if (!opts.enabled) {
+    if (!enabled) {
       return;
     }
 
@@ -234,13 +234,14 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [isDirty, tenantId, programs, forms, ctas, branches, contentShowcase, opts.enabled]);
+  }, [isDirty, tenantId, enabled, saveToStorage]);
 
-  // Return utilities
+  // Return utilities. lastSaveTime is exposed as a getter so callers don't
+  // read ref.current during render (react-hooks/refs).
   return {
     saveToStorage,
     loadFromStorage,
     clearAutoSave,
-    lastSaveTime: lastSaveRef.current,
+    getLastSaveTime: () => lastSaveRef.current,
   };
 }


### PR DESCRIPTION
## Summary

Knocks out 10 of the remaining `react-hooks/*` violations. **Lint baseline: 171 → 161 (-10).** The 12 `set-state-in-effect` cases (plus `ValidationPanel.tsx`'s coupled `exhaustive-deps` warning) are **deferred to B3** for case-by-case audit — see "Deferred to B3" section below.

Follow-up to #28.

## Changes

### 1. `FieldCollection.tsx` — `react-hooks/purity` (1)
Extracted `Date.now()`-using ID generators (`newFieldId`, `duplicateFieldId`) to module scope. The original calls were inside click handlers (post-render), but the rule flags `Date.now()` syntactically inside a component body. Behavior identical.

### 2. `ProgramForm.tsx` — `react-hooks/preserve-manual-memoization` (1)
Extracted `program?.program_id` optional chain to a `currentProgramId` local before the `useCallback` so the memo's dep array is statically analyzable. Behavior identical. _The `set-state-in-effect` violation in this same file is deferred to B3._

### 3. `CreateTenantModal.tsx` — `react-hooks/incompatible-library` (1)
Switched `react-hook-form`'s `watch('field')` to `useWatch({ control, name: 'field' })` for both watched values (`primary_color`, `subscription_tier`). `useWatch` is the compiler-friendly subscription pattern; `watch()` returns a function that can't be memoized safely.

CreateTenantModal has direct test coverage — all tests still pass.

### 4. `useEntityCRUD.ts` — `react-hooks/exhaustive-deps` (1)
Dropped unused `getId` dep from `openEditModal`'s `useCallback`. The function body doesn't reference `getId` — it was an over-listed dep that destabilized the callback ref unnecessarily.

### 5. `useAutoSave.ts` — `react-hooks/exhaustive-deps` (4) + `react-hooks/refs` (2)
- Wrapped `saveToStorage` / `loadFromStorage` / `clearAutoSave` in `useCallback` with proper deps. Each effect now lists the memoized callback in its dep array; behavior preserved (effects re-fire on the same data changes since the callbacks themselves depend on the data).
- Renamed `lastSaveTime: lastSaveRef.current` (ref-read-during-render) to `getLastSaveTime: () => lastSaveRef.current` (function call). Verified zero callers via grep — safe API change.

## Verification

- [x] `npm run lint`: 171 → 161 problems (all Phase B2 categories cleared except 1 deferred warning)
- [x] `npm run typecheck`: clean
- [x] `npm run test:run`: 437/437 passing

### Test-coverage gaps (waived)

Recorded in verify marker:

- **useAutoSave.ts** — dev-time UX (auto-save cadence, not data integrity). Behavioral preservation verified by code-reading analysis: each useCallback's deps trace correctly to function captures; effects' deps include the memoized callbacks so they re-fire when data changes (same trigger as before). User-approved waiver.
- **FieldCollection / ProgramForm / useEntityCRUD** — pre-existing test gaps; semantics-preserving structural refactors (same waiver pattern as #27/#28).

## Deferred to B3

After landing this PR, **161 problems remain**:
- **148** `@typescript-eslint/no-explicit-any` → Phase C (separate effort)
- **12** `react-hooks/set-state-in-effect` → B3 (next PR)
- **1** `react-hooks/exhaustive-deps` warning in `ValidationPanel.tsx` → B3 (coupled to that file's set-state-in-effect; both fix together)

The B3 work is being assigned to a separate-session agent; a self-contained handoff issue with file:line locations + the React-pattern decision tree for each case will be filed once this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)