### PR TITLE
chore(lint): Phase C1 — test-file no-explicit-any cleanup (-55 violations)

### DIFF
--- a/src/__tests__/integration/deploymentWorkflow.test.tsx
+++ b/src/__tests__/integration/deploymentWorkflow.test.tsx
@@ -22,6 +22,7 @@ import {
   resetConfigStore,
 } from './testUtils';
 import * as configOps from '@/lib/api/config-operations';
+import type { TenantConfig } from '@/types/config';
 
 // Mock the config operations module
 vi.mock('@/lib/api/config-operations', () => ({
@@ -59,17 +60,17 @@ describe('S3 Deployment Workflow Integration Tests', () => {
     mockS3 = createMockS3API();
 
     // Mock all config operations
-    (configOps.loadConfig as any).mockImplementation((tenantId: string) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId: string) =>
       mockS3.loadConfig(tenantId)
     );
-    (configOps.saveConfig as any).mockImplementation((tenantId: string, config: any, options?: any) =>
+    vi.mocked(configOps.saveConfig).mockImplementation((tenantId, config, options) =>
       mockS3.saveConfig(tenantId, config, options)
     );
-    (configOps.deployConfig as any).mockImplementation((tenantId: string, config: any) =>
+    vi.mocked(configOps.deployConfig).mockImplementation((tenantId, config) =>
       mockS3.deployConfig(tenantId, config)
     );
-    (configOps.listTenants as any).mockImplementation(() => mockS3.listTenants());
-    (configOps.getTenantMetadata as any).mockImplementation((tenantId: string) =>
+    vi.mocked(configOps.listTenants).mockImplementation(() => mockS3.listTenants());
+    vi.mocked(configOps.getTenantMetadata).mockImplementation((tenantId: string) =>
       mockS3.getTenantMetadata(tenantId)
     );
 
@@ -197,7 +198,7 @@ describe('S3 Deployment Workflow Integration Tests', () => {
         description: 'Test description',
         keywords: ['test'],
       },
-    ] as any;
+    ] as TenantConfig['content_showcase'];
 
     mockS3._setMockConfig('TEST_TENANT', testConfig);
 
@@ -222,7 +223,7 @@ describe('S3 Deployment Workflow Integration Tests', () => {
     // Verify content_showcase preserved (shape is a flat array in the deployed config)
     const deployedConfig = mockS3._getMockConfig('TEST_TENANT');
     expect(deployedConfig!.content_showcase).toBeDefined();
-    expect(deployedConfig!.content_showcase as any[]).toHaveLength(1);
+    expect(deployedConfig!.content_showcase).toHaveLength(1);
   });
 
   it('should bump version on deployment', async () => {
@@ -265,10 +266,10 @@ describe('S3 Deployment Workflow Integration Tests', () => {
     // Create minimal config with only programs. Note: the payload field
     // names are `cta_definitions` and `conversation_branches` (not `ctas`
     // and `routing`), matching the current Lambda contract.
-    const minimalConfig = createTestTenantConfig('TEST_TENANT');
-    delete (minimalConfig as any).conversational_forms;
-    delete (minimalConfig as any).cta_definitions;
-    delete (minimalConfig as any).conversation_branches;
+    const minimalConfig: Partial<TenantConfig> = createTestTenantConfig('TEST_TENANT');
+    delete minimalConfig.conversational_forms;
+    delete minimalConfig.cta_definitions;
+    delete minimalConfig.conversation_branches;
 
     mockS3._setMockConfig('TEST_TENANT', minimalConfig);
 

--- a/src/__tests__/integration/edgeCases.test.tsx
+++ b/src/__tests__/integration/edgeCases.test.tsx
@@ -23,6 +23,7 @@ import {
   getEntityWarnings,
 } from './testUtils';
 import * as configOps from '@/lib/api/config-operations';
+import type { FormField } from '@/types/config';
 
 vi.mock('@/lib/api/config-operations', () => ({
   loadConfig: vi.fn(),
@@ -75,7 +76,7 @@ describe('Edge Cases Integration Tests', () => {
     };
 
     mockS3._setMockConfig('EMPTY_TENANT', emptyConfig);
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
 
@@ -111,10 +112,10 @@ describe('Edge Cases Integration Tests', () => {
     const largeConfig = createLargeTenantConfig(10, 3, 2, 30);
 
     mockS3._setMockConfig('LARGE_TENANT', largeConfig);
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
-    (configOps.saveConfig as any).mockImplementation((tenantId, config, options) =>
+    vi.mocked(configOps.saveConfig).mockImplementation((tenantId, config, options) =>
       mockS3.saveConfig(tenantId, config, options)
     );
 
@@ -248,8 +249,8 @@ describe('Edge Cases Integration Tests', () => {
             label: 'Select',
             prompt: 'Choose an option',
             required: true,
-            options: [], // Select with no options — should be invalid
-          } as any,
+            options: [], // Select with no options — intentionally invalid for the validation test
+          } as unknown as FormField,
         ],
       });
     });
@@ -452,7 +453,7 @@ describe('Edge Cases Integration Tests', () => {
     };
 
     mockS3._setMockConfig('MINIMAL_TENANT', minimalConfig);
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
 

--- a/src/__tests__/integration/errorHandling.test.tsx
+++ b/src/__tests__/integration/errorHandling.test.tsx
@@ -24,6 +24,7 @@ import {
   getEntityWarnings,
 } from './testUtils';
 import * as configOps from '@/lib/api/config-operations';
+import type { TenantConfig } from '@/types/config';
 
 vi.mock('@/lib/api/config-operations', () => ({
   loadConfig: vi.fn(),
@@ -64,7 +65,7 @@ describe('Error Handling Integration Tests', () => {
 
     // Setup mock to fail on load
     const mockS3 = createMockS3APIWithErrors('notfound');
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
 
@@ -95,10 +96,10 @@ describe('Error Handling Integration Tests', () => {
     const testConfig = createTestTenantConfig('TEST_TENANT');
     mockS3._setMockConfig('TEST_TENANT', testConfig);
 
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
-    (configOps.saveConfig as any).mockRejectedValue(new Error('Network timeout'));
+    vi.mocked(configOps.saveConfig).mockRejectedValue(new Error('Network timeout'));
 
     // Load config
     await act(async () => {
@@ -144,10 +145,10 @@ describe('Error Handling Integration Tests', () => {
     const testConfig = createTestTenantConfig('TEST_TENANT');
     mockS3._setMockConfig('TEST_TENANT', testConfig);
 
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
-    (configOps.deployConfig as any).mockImplementation((tenantId, config) =>
+    vi.mocked(configOps.deployConfig).mockImplementation((tenantId, config) =>
       mockS3.deployConfig(tenantId, config)
     );
 
@@ -256,18 +257,19 @@ describe('Error Handling Integration Tests', () => {
   it('should handle invalid config structure on load', async () => {
     const { result } = renderHook(() => useConfigStore());
 
-    // Create invalid config
+    // Create invalid config — intentionally violates the TenantConfig schema
+    // so we can exercise the validation pipeline's bad-input branch.
     const invalidConfig = {
       tenant_id: 'TEST_TENANT',
       // Missing version
       // Missing generated_at
       programs: 'invalid', // Should be object
-    } as any;
+    } as unknown as TenantConfig;
 
     const mockS3 = createMockS3API();
     mockS3._setMockConfig('TEST_TENANT', invalidConfig);
 
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
 
@@ -295,14 +297,14 @@ describe('Error Handling Integration Tests', () => {
 
     // Setup mock to fail validation
     const mockS3 = createMockS3APIWithErrors('validation');
-    (configOps.saveConfig as any).mockImplementation((tenantId, config, options) =>
+    vi.mocked(configOps.saveConfig).mockImplementation((tenantId, config, options) =>
       mockS3.saveConfig(tenantId, config, options)
     );
 
     const testConfig = createTestTenantConfig('TEST_TENANT');
     mockS3._setMockConfig('TEST_TENANT', testConfig);
 
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
 
@@ -343,10 +345,10 @@ describe('Error Handling Integration Tests', () => {
     const testConfig = createTestTenantConfig('TEST_TENANT');
     mockS3._setMockConfig('TEST_TENANT', testConfig);
 
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
-    (configOps.saveConfig as any).mockImplementation((tenantId, config, options) =>
+    vi.mocked(configOps.saveConfig).mockImplementation((tenantId, config, options) =>
       mockS3.saveConfig(tenantId, config, options)
     );
 
@@ -535,7 +537,7 @@ describe('Error Handling Integration Tests', () => {
     const { result } = renderHook(() => useConfigStore());
 
     const mockS3 = createMockS3API();
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
 
@@ -562,10 +564,10 @@ describe('Error Handling Integration Tests', () => {
     const testConfig = createTestTenantConfig('TEST_TENANT');
     mockS3._setMockConfig('TEST_TENANT', testConfig);
 
-    (configOps.loadConfig as any).mockImplementation((tenantId) =>
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
       mockS3.loadConfig(tenantId)
     );
-    (configOps.deployConfig as any).mockRejectedValue(new Error('Deployment failed'));
+    vi.mocked(configOps.deployConfig).mockRejectedValue(new Error('Deployment failed'));
 
     // Load config
     await act(async () => {

--- a/src/__tests__/integration/testUtils.ts
+++ b/src/__tests__/integration/testUtils.ts
@@ -12,6 +12,21 @@ import type {
   ConversationBranch,
   TenantConfig,
 } from '@/types/config';
+import type { ValidationError } from '@/types/validation';
+import type { ConfigBuilderState } from '@/store/types';
+
+// Minimal validation-state shape used by the helpers below.
+// Matches the relevant subset of ValidationSlice from the store.
+type ValidationStateLike = {
+  errors?: Record<string, ValidationError[]>;
+  warnings?: Record<string, ValidationError[]>;
+};
+
+// Minimal store shape used by resetConfigStore — anything exposing
+// Immer-style setState against ConfigBuilderState satisfies it.
+type ConfigStoreLike = {
+  setState: (fn: (state: ConfigBuilderState) => void) => void;
+};
 
 // ============================================================================
 // MOCK FACTORIES
@@ -176,7 +191,7 @@ export function createTestTenantConfig(
       'branch-1': branch,
     },
     ...overrides,
-  } as any;
+  } as TenantConfig;
 }
 
 // ============================================================================
@@ -284,20 +299,15 @@ export function createLargeTenantConfig(
   ctasPerForm: number = 2,
   branchCount: number = 30
 ): TenantConfig {
-  const config: any = {
-    tenant_id: 'LARGE_TENANT',
-    version: '1.3.0',
-    generated_at: Date.now(),
-    programs: {},
-    conversational_forms: {},
-    cta_definitions: {},
-    conversation_branches: {},
-  };
+  const programs: Record<string, Program> = {};
+  const conversational_forms: Record<string, ConversationalForm> = {};
+  const cta_definitions: Record<string, CTADefinition> = {};
+  const conversation_branches: Record<string, ConversationBranch> = {};
 
   // Create programs
   for (let p = 0; p < programCount; p++) {
     const programId = `program-${p + 1}`;
-    config.programs[programId] = createTestProgram({
+    programs[programId] = createTestProgram({
       program_id: programId,
       program_name: `Program ${p + 1}`,
     });
@@ -305,7 +315,7 @@ export function createLargeTenantConfig(
     // Create forms for each program
     for (let f = 0; f < formsPerProgram; f++) {
       const formId = `form-${p + 1}-${f + 1}`;
-      config.conversational_forms![formId] = createTestForm(programId, 5, {
+      conversational_forms[formId] = createTestForm(programId, 5, {
         form_id: formId,
         title: `Form ${p + 1}-${f + 1}`,
       });
@@ -313,7 +323,7 @@ export function createLargeTenantConfig(
       // Create CTAs for each form
       for (let c = 0; c < ctasPerForm; c++) {
         const ctaId = `cta-${p + 1}-${f + 1}-${c + 1}`;
-        config.cta_definitions[ctaId] = createTestCTA(formId, {
+        cta_definitions[ctaId] = createTestCTA(formId, {
           label: `CTA ${p + 1}-${f + 1}-${c + 1}`,
         });
       }
@@ -321,16 +331,24 @@ export function createLargeTenantConfig(
   }
 
   // Create branches
-  const allCtaIds = Object.keys(config.cta_definitions);
+  const allCtaIds = Object.keys(cta_definitions);
   for (let b = 0; b < branchCount; b++) {
     const branchId = `branch-${b + 1}`;
     const primaryCtaId = allCtaIds[b % allCtaIds.length];
-    config.conversation_branches[branchId] = createTestBranch(primaryCtaId, {
+    conversation_branches[branchId] = createTestBranch(primaryCtaId, {
       detection_keywords: [`keyword-${b + 1}`, `topic-${b + 1}`],
     });
   }
 
-  return config;
+  return {
+    tenant_id: 'LARGE_TENANT',
+    version: '1.3.0',
+    generated_at: Date.now(),
+    programs,
+    conversational_forms,
+    cta_definitions,
+    conversation_branches,
+  } as TenantConfig;
 }
 
 // ============================================================================
@@ -354,14 +372,14 @@ export async function waitForStoreUpdate(checkFn: () => boolean, timeout: number
 /**
  * Extract all validation errors from store state
  */
-export function extractValidationErrors(validationState: any): string[] {
+export function extractValidationErrors(validationState: ValidationStateLike): string[] {
   const errors: string[] = [];
 
   // New validation structure uses errors and warnings objects keyed by entityId
   if (validationState.errors) {
-    Object.values(validationState.errors).forEach((entityErrors: any) => {
+    Object.values(validationState.errors).forEach((entityErrors) => {
       if (Array.isArray(entityErrors)) {
-        entityErrors.forEach((error: any) => {
+        entityErrors.forEach((error) => {
           errors.push(error.message);
         });
       }
@@ -374,13 +392,13 @@ export function extractValidationErrors(validationState: any): string[] {
 /**
  * Extract all validation warnings from store state
  */
-export function extractValidationWarnings(validationState: any): string[] {
+export function extractValidationWarnings(validationState: ValidationStateLike): string[] {
   const warnings: string[] = [];
 
   if (validationState.warnings) {
-    Object.values(validationState.warnings).forEach((entityWarnings: any) => {
+    Object.values(validationState.warnings).forEach((entityWarnings) => {
       if (Array.isArray(entityWarnings)) {
-        entityWarnings.forEach((warning: any) => {
+        entityWarnings.forEach((warning) => {
           warnings.push(warning.message);
         });
       }
@@ -393,26 +411,34 @@ export function extractValidationWarnings(validationState: any): string[] {
 /**
  * Get validation errors for a specific entity
  */
-export function getEntityErrors(validationState: any, entityId: string): any[] {
+export function getEntityErrors(
+  validationState: ValidationStateLike,
+  entityId: string,
+): ValidationError[] {
   return validationState.errors?.[entityId] || [];
 }
 
 /**
  * Get validation warnings for a specific entity
  */
-export function getEntityWarnings(validationState: any, entityId: string): any[] {
+export function getEntityWarnings(
+  validationState: ValidationStateLike,
+  entityId: string,
+): ValidationError[] {
   return validationState.warnings?.[entityId] || [];
 }
 
 /**
  * Calculate validation summary from errors and warnings
  */
-export function getValidationSummary(validationState: any): { totalErrors: number; totalWarnings: number } {
+export function getValidationSummary(
+  validationState: ValidationStateLike,
+): { totalErrors: number; totalWarnings: number } {
   let totalErrors = 0;
   let totalWarnings = 0;
 
   if (validationState.errors) {
-    Object.values(validationState.errors).forEach((entityErrors: any) => {
+    Object.values(validationState.errors).forEach((entityErrors) => {
       if (Array.isArray(entityErrors)) {
         totalErrors += entityErrors.length;
       }
@@ -420,7 +446,7 @@ export function getValidationSummary(validationState: any): { totalErrors: numbe
   }
 
   if (validationState.warnings) {
-    Object.values(validationState.warnings).forEach((entityWarnings: any) => {
+    Object.values(validationState.warnings).forEach((entityWarnings) => {
       if (Array.isArray(entityWarnings)) {
         totalWarnings += entityWarnings.length;
       }
@@ -434,8 +460,8 @@ export function getValidationSummary(validationState: any): { totalErrors: numbe
  * Reset Zustand store to clean state for testing
  * Import useConfigStore in your test and call this in beforeEach
  */
-export function resetConfigStore(useConfigStore: any) {
-  useConfigStore.setState((state: any) => {
+export function resetConfigStore(useConfigStore: ConfigStoreLike) {
+  useConfigStore.setState((state) => {
     // Reset only data properties, preserve all action methods
     state.programs.programs = {};
     state.programs.activeProgramId = null;

--- a/src/components/dashboard/__tests__/ConversationFlowDiagram.test.tsx
+++ b/src/components/dashboard/__tests__/ConversationFlowDiagram.test.tsx
@@ -21,6 +21,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { ConversationFlowDiagram } from '../ConversationFlowDiagram';
 import { useConfigStore } from '@/store';
 import type { Program, ConversationalForm, CTADefinition, ConversationBranch, ActionChip } from '@/types/config';
+import type { ValidationError } from '@/types/validation';
 
 // Mock the store
 vi.mock('@/store', () => ({
@@ -798,7 +799,7 @@ describe('ConversationFlowDiagram', () => {
 
       // Create 15 entities with errors
       const manyPrograms: Record<string, Program> = {};
-      const manyErrors: Record<string, any[]> = {};
+      const manyErrors: Record<string, ValidationError[]> = {};
 
       for (let i = 1; i <= 15; i++) {
         const progId = `prog-${i}`;

--- a/src/store/__tests__/programsSlice.test.ts
+++ b/src/store/__tests__/programsSlice.test.ts
@@ -11,7 +11,13 @@ import { createProgramsSlice } from '../slices/programs';
 import { createFormsSlice } from '../slices/forms';
 import { createUISlice } from '../slices/ui';
 import { createConfigSlice } from '../slices/config';
-import type { AppState } from '../types';
+import type {
+  AppState,
+  CTAsSlice,
+  BranchesSlice,
+  ContentShowcaseSlice,
+  ValidationSlice,
+} from '../types';
 
 describe('Programs Slice', () => {
   let useStore: ReturnType<typeof create<AppState>>;
@@ -22,13 +28,13 @@ describe('Programs Slice', () => {
       immer((...args) => ({
         programs: createProgramsSlice(...args),
         forms: createFormsSlice(...args),
-        ctas: {} as any,
-        branches: {} as any,
-        cardInventory: {} as any,
-        contentShowcase: {} as any,
+        ctas: {} as unknown as CTAsSlice,
+        branches: {} as unknown as BranchesSlice,
+        cardInventory: {} as unknown as Record<string, never>,
+        contentShowcase: {} as unknown as ContentShowcaseSlice,
         ui: createUISlice(...args),
         config: createConfigSlice(...args),
-        validation: { validateAll: vi.fn() } as any,
+        validation: { validateAll: vi.fn() } as unknown as ValidationSlice,
       }))
     );
   });


### PR DESCRIPTION
## Summary

Knocks out all 55 `@typescript-eslint/no-explicit-any` violations in test files. **Lint baseline: 161 → 106 (-55).** Type-only changes; the 437-test suite passes unchanged.

Follow-up to #29 (Phase B2). First of four Phase C subdivisions per the updated plan.

## Changes

| File | Anys cleared | Pattern |
|---|---|---|
| `src/__tests__/integration/testUtils.ts` | 17 | `ValidationStateLike` + `ConfigStoreLike` helper interfaces; typed `TenantConfig` casts; rewrote `createLargeTenantConfig` to build typed `Record<string, X>` locals |
| `src/__tests__/integration/errorHandling.test.tsx` | 14 | 13× `vi.mocked(configOps.X)` instead of `(configOps.X as any)`; one `as unknown as TenantConfig` for an intentionally-invalid test fixture |
| `src/__tests__/integration/deploymentWorkflow.test.tsx` | 13 | 5× `vi.mocked()` swap; dropped redundant inline `:any` mock args; `as TenantConfig['content_showcase']`; `Partial<TenantConfig>` for the `delete X.foo` pattern |
| `src/__tests__/integration/edgeCases.test.tsx` | 5 | 3× `vi.mocked()`; `as unknown as FormField` for invalid-select test fixture |
| `src/store/__tests__/programsSlice.test.ts` | 5 | Named casts for slice placeholders (`as unknown as CTAsSlice` etc.) |
| `src/components/dashboard/__tests__/ConversationFlowDiagram.test.tsx` | 1 | Typed `manyErrors` as `Record<string, ValidationError[]>` |

### Why these patterns

- **`vi.mocked(X)` over `(X as any)`** — vitest's official typed mock accessor. Returns the mock with proper signature; eliminates the need for inline `:any` argument types on `mockImplementation`.
- **`as unknown as T` for intentionally-invalid fixtures** — signals "I know this violates the schema; the test is exercising the validation pipeline's bad-input branch." Better than `as any` because the resulting variable has a known type.
- **Helper interfaces (`ValidationStateLike`, `ConfigStoreLike`) over imports** — testUtils is a generic helper; it shouldn't tightly couple to the full `ConfigBuilderState`. Local interfaces describe the minimum surface each helper needs.
- **`as unknown as <Slice>` for store placeholders** — the programsSlice test deliberately stubs out unrelated slices with `{}` to isolate the program logic. The double-cast satisfies the type system without lying about the runtime value.

## Verification

- [x] `npm run lint`: 161 → 106 problems (all test-file anys cleared; remaining 106 = 93 production-code anys for C2/C3/C4 + 13 deferred to B3)
- [x] `npm run typecheck`: clean
- [x] `npm run test:run`: 437/437 passing

### Test-coverage gap

Changes are type-only. The test suite IS the verification surface — if these tests still pass after the type changes, the type changes are sound. Same waiver pattern as #27/#28/#29 (recorded in verify marker).

## Remaining lint debt after C1

| Phase | Rules | Count |
|---|---|---|
| **C2** | `no-explicit-any` in `src/lib/` (mergeStrategy + others) | 33 |
| **C3** | `no-explicit-any` in `src/store/` (slices + types) | 14 |
| **C4** | `no-explicit-any` in `src/components/` + `src/hooks/` | 46 |
| **B3** | `react-hooks/set-state-in-effect` ×12 + ValidationPanel exhaustive-deps ×1 | 13 (issue #30) |
| | _Total remaining_ | **106** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)