### PR TITLE
chore(lint): Phase C3 — store any cleanup (-14 violations)

### DIFF
--- a/src/store/slices/config.ts
+++ b/src/store/slices/config.ts
@@ -3,7 +3,7 @@
  * Manages configuration lifecycle: load, save, deploy, and merge operations
  */
 
-import type { TenantConfig } from '@/types/config';
+import type { TenantConfig, ConversationalForm } from '@/types/config';
 import type { SliceCreator, ConfigSlice } from '../types';
 import * as configAPI from '@/lib/api/config-operations';
 import { configApiClient } from '@/lib/api/client';
@@ -232,8 +232,11 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         // Preserve topic_definitions from baseConfig for V4.1 Lambda compat (read-only passthrough)
         ...(mergedConfig.topic_definitions?.length && { topic_definitions: mergedConfig.topic_definitions }),
         feature_flags: mergedConfig.feature_flags || {},
-        ...((mergedConfig as any).form_settings && { form_settings: (mergedConfig as any).form_settings }),
-        ...((mergedConfig as any).monitor && { monitor: (mergedConfig as any).monitor }),
+        // form_settings is a legacy passthrough not in TenantConfig's typed surface
+        ...((mergedConfig as TenantConfig & { form_settings?: unknown }).form_settings
+          ? { form_settings: (mergedConfig as TenantConfig & { form_settings?: unknown }).form_settings }
+          : {}),
+        ...(mergedConfig.monitor ? { monitor: mergedConfig.monitor } : {}),
         // Metadata fields
         chat_title: mergedConfig.chat_title,
         welcome_message: mergedConfig.welcome_message,
@@ -436,7 +439,7 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         // Normalize forms: ensure form_id matches the dictionary key
         const forms = draftConfig.conversational_forms || {};
         state.forms.forms = Object.fromEntries(
-          Object.entries(forms).map(([key, form]: [string, any]) => [
+          Object.entries(forms).map(([key, form]: [string, ConversationalForm]) => [
             key,
             { ...form, form_id: key },
           ])
@@ -606,16 +609,35 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
       ...(state.config.baseConfig.topic_definitions?.length && { topic_definitions: state.config.baseConfig.topic_definitions }),
       // Feature flags — always include so V4 flags can be set from scratch
       feature_flags: state.config.baseConfig.feature_flags || {},
-      ...((state.config.baseConfig as any).form_settings && { form_settings: (state.config.baseConfig as any).form_settings }),
+      // form_settings is a legacy passthrough not in TenantConfig's typed surface
+      ...((state.config.baseConfig as TenantConfig & { form_settings?: unknown }).form_settings
+        ? { form_settings: (state.config.baseConfig as TenantConfig & { form_settings?: unknown }).form_settings }
+        : {}),
       ...(state.config.baseConfig.notification_settings && { notification_settings: state.config.baseConfig.notification_settings }),
     };
 
     // Post-process forms: map post_submission.fulfillment → root-level fulfillment
     // for Lambda compatibility (Lambda reads form.fulfillment.type, not form.post_submission.fulfillment.method)
+    // Lift post_submission.fulfillment → root-level fulfillment for Lambda compat.
+    // The deployed shape uses different field names (type/email_to/template) than
+    // the local Fulfillment type — cast through unknown to express the intentional
+    // shape divergence at the Lambda boundary.
+    type DeployedFulfillment = {
+      type: string;
+      email_to?: string[];
+      cc?: string[];
+      webhook_url?: string;
+      template: string;
+    };
     for (const [formId, form] of Object.entries(mergedConfig.conversational_forms)) {
-      const ps = (form as any).post_submission;
-      if (ps?.fulfillment && !((form as any).fulfillment)) {
-        (mergedConfig.conversational_forms[formId] as any).fulfillment = {
+      const ps = form.post_submission;
+      const formWithLambdaFulfillment = form as ConversationalForm & {
+        fulfillment?: DeployedFulfillment;
+      };
+      if (ps?.fulfillment && !formWithLambdaFulfillment.fulfillment) {
+        (mergedConfig.conversational_forms[formId] as ConversationalForm & {
+          fulfillment?: DeployedFulfillment;
+        }).fulfillment = {
           type: ps.fulfillment.method || 'email',
           email_to: ps.fulfillment.recipients,
           cc: ps.fulfillment.cc,

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -51,7 +51,7 @@ export const createUISlice: SliceCreator<UISlice> = (set, get) => ({
     });
   },
 
-  pushModal: (type: string, props: Record<string, any>) => {
+  pushModal: (type: string, props: Record<string, unknown>) => {
     set((state) => {
       state.ui.modalStack.push({ type, props });
     });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -3,6 +3,7 @@
  * Type definitions for Zustand store slices and state
  */
 
+import type { StoreApi } from 'zustand';
 import type {
   Program,
   ConversationalForm,
@@ -39,7 +40,7 @@ export interface Toast {
 
 export interface Modal {
   type: string;
-  props: Record<string, any>;
+  props: Record<string, unknown>;
 }
 
 // ============================================================================
@@ -193,7 +194,7 @@ export interface UISlice {
   toggleSidebar: () => void;
   openEditor: (editor: EditorType, entityId: string | null) => void;
   closeEditor: () => void;
-  pushModal: (type: string, props: Record<string, any>) => void;
+  pushModal: (type: string, props: Record<string, unknown>) => void;
   popModal: () => void;
   clearModals: () => void;
   setLoading: (key: string, loading: boolean) => void;
@@ -320,5 +321,5 @@ export interface ConfigBuilderState {
 export type SliceCreator<T> = (
   set: (fn: (state: ConfigBuilderState) => void) => void,
   get: () => ConfigBuilderState,
-  api: any
+  api: StoreApi<ConfigBuilderState>
 ) => T;


### PR DESCRIPTION
## Summary

Knocks out all 14 `no-explicit-any` violations in `src/store/`. **Lint baseline: 74 → 60 (-14, exactly the target).** Type-only changes; the 437-test suite passes unchanged.

Follow-up to #32 (Phase C2). Third of four Phase C subdivisions.

## Changes

### `src/store/types.ts` (-3)
- `Modal.props: Record<string, any>` → `Record<string, unknown>`
- `UISlice.pushModal`'s `props: Record<string, any>` → `Record<string, unknown>`
- `SliceCreator`'s `api: any` → `StoreApi<ConfigBuilderState>` (imported from `zustand`)

### `src/store/slices/ui.ts` (-1)
- `pushModal` implementation signature matches the slice interface change

### `src/store/slices/config.ts` (-10)
- **Legacy `form_settings` passthrough (lines 235-236, 609):** typed via `(x as TenantConfig & { form_settings?: unknown })` since `form_settings` isn't in the strict `TenantConfig` type. Also converted `&&`-spread to ternary — TS rejects `false` as a spread source once `any` narrows away.
- **`Object.entries` map destructure (line 442):** `[string, any]` → `[string, ConversationalForm]`.
- **`monitor` field access (line 236):** dropped `as any` cast — `monitor` IS in `TenantConfig`; converted spread pattern to ternary.
- **Form `fulfillment` lifting for Lambda compat (lines 614-628):** the deployed shape differs from local `Fulfillment` (`type`/`email_to`/`template` vs `method`/`recipients`/`subject_template`). Defined local `DeployedFulfillment` type to express the Lambda-boundary shape divergence; cast through `ConversationalForm & { fulfillment?: DeployedFulfillment }` for both the read check and the write.

## Verification

- [x] `npm run lint`: 74 → 60 problems (all store anys cleared)
- [x] `npm run typecheck`: clean
- [x] `npm run test:run`: 437/437 passing

### Test-coverage gap (waived)

Pre-existing gap (no direct unit tests for `config.ts` slice). Type-only changes preserve runtime behavior identically; `deploymentWorkflow`/`errorHandling` integration tests exercise the merge/load/draft paths end-to-end. Same waiver pattern as #27/#28/#29/#31/#32.

## Remaining lint debt

| Phase | Rules | Count |
|---|---|---|
| **C4** | `no-explicit-any` in `src/components/` + `src/hooks/` (settings cluster + 9 other components + 1 hook) | 46 |
| **B3** | `react-hooks/set-state-in-effect` ×12 + ValidationPanel exhaustive-deps ×1 | 13 (issue #30) |
| Final | Flip `continue-on-error: true` → `false` on lint job | — |
| | _Total remaining_ | **60** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)