### PR TITLE
chore(lint): Phase C4 — UI any cleanup (-47 violations)

### DIFF
--- a/src/components/TenantSelector.tsx
+++ b/src/components/TenantSelector.tsx
@@ -10,6 +10,7 @@ import { useConfigStore } from '@/store';
 import { listTenants } from '@/lib/api';
 import { useAuth } from '@/context/AuthContext';
 import type { SelectOption } from './ui/Select';
+import type { TenantListItem } from '@/types/api';
 
 interface TenantSelectorProps {
   className?: string;
@@ -55,7 +56,7 @@ export const TenantSelector: React.FC<TenantSelectorProps> = ({
         const tenantsList = await listTenants();
 
         // Convert tenant list to select options
-        let options: SelectOption[] = tenantsList.map((tenant: any) => ({
+        let options: SelectOption[] = tenantsList.map((tenant: TenantListItem) => ({
           value: tenant.tenantId,
           label: tenant.tenantName || tenant.tenantId,
         }));

--- a/src/components/dashboard/ConversationFlowDiagram.tsx
+++ b/src/components/dashboard/ConversationFlowDiagram.tsx
@@ -159,7 +159,7 @@ export const ConversationFlowDiagram: React.FC<ConversationFlowDiagramProps> = (
   /**
    * Build tooltip content for metrics
    */
-  const buildTooltipContent = useCallback((entities: any[], maxDisplay = 10) => {
+  const buildTooltipContent = useCallback((entities: Array<{ id: string; label: string; type?: string }>, maxDisplay = 10) => {
     if (!entities || entities.length === 0) return null;
 
     const displayEntities = entities.slice(0, maxDisplay);

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -33,7 +33,7 @@ export interface TreeNode {
   errorCount: number;
   warningCount: number;
   children: TreeNode[];
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   richMetadata?: BranchMetadata | CTAMetadata | FormMetadata | ProgramMetadata | ActionChipMetadata | ShowcaseMetadata;
   statusIcons?: StatusIcon[];
 }

--- a/src/components/deploy/DeployButton.tsx
+++ b/src/components/deploy/DeployButton.tsx
@@ -11,6 +11,7 @@ import { useConfigStore } from '@/store';
 import { prepareConfigForDeployment } from '@/lib/api/mergeStrategy';
 import { deployConfig } from '@/lib/api/config-operations';
 import { configApiClient } from '@/lib/api/client';
+import type { TenantConfig } from '@/types/config';
 
 export interface DeployButtonProps {
   className?: string;
@@ -111,7 +112,7 @@ export const DeployButton: React.FC<DeployButtonProps> = ({ className = '' }) =>
       });
 
       // Deploy to S3 (or local dev server) with merge=false for full replacement
-      await deployConfig(tenantId, mergedConfig as any);
+      await deployConfig(tenantId, mergedConfig as TenantConfig);
 
       // Mark as not dirty
       markClean();

--- a/src/components/editors/BranchesEditor/BranchesEditor.tsx
+++ b/src/components/editors/BranchesEditor/BranchesEditor.tsx
@@ -17,7 +17,7 @@ import { BranchCardContent } from './BranchCardContent';
 import { validateBranch } from '@/lib/validation/formValidators';
 import { useConfigStore } from '@/store';
 import type { BranchEntity } from './types';
-import type { EntityDependencies } from '@/lib/crud/types';
+import type { EntityDependencies, ValidationContext } from '@/lib/crud/types';
 import type { ConversationBranch } from '@/types/config';
 
 /**
@@ -52,7 +52,7 @@ export const BranchesEditor: React.FC = () => {
 
   // Wrap validator to inject maxCtasPerResponse
   const branchValidator = useMemo(() => {
-    return (data: BranchEntity, context: any) => {
+    return (data: BranchEntity, context: ValidationContext<BranchEntity>) => {
       return validateBranch(data, { ...context, maxCtasPerResponse });
     };
   }, [maxCtasPerResponse]);

--- a/src/components/editors/CTAEditor/CTAForm.tsx
+++ b/src/components/editors/CTAEditor/CTAForm.tsx
@@ -168,7 +168,7 @@ export const CTAForm: React.FC<CTAFormProps> = ({
     query: cta?.query || '',
     prompt: cta?.prompt || '',
     type: cta?.type || 'form_trigger',
-    style: (cta as any)?.style || 'primary', // style deprecated in v1.5
+    style: (cta as CTADefinition & { style?: CTAStyle })?.style || 'primary', // style deprecated in v1.5
   });
 
   const [errors, setErrors] = useState<FormErrors>({});
@@ -205,7 +205,7 @@ export const CTAForm: React.FC<CTAFormProps> = ({
         query: cta?.query || '',
         prompt: cta?.prompt || '',
         type: cta?.type || 'form_trigger',
-        style: (cta as any)?.style || 'primary', // style deprecated in v1.5
+        style: (cta as CTADefinition & { style?: CTAStyle })?.style || 'primary', // style deprecated in v1.5
       });
       setErrors({});
       setTouched({});

--- a/src/components/editors/FormsEditor/FormFormFields.tsx
+++ b/src/components/editors/FormsEditor/FormFormFields.tsx
@@ -173,7 +173,7 @@ export const FormFormFields: React.FC<FormFieldsProps<ConversationalForm>> = ({
       <PostSubmissionConfig
         value={value.post_submission}
         onChange={(newConfig) => onChange({ ...value, post_submission: newConfig })}
-        errors={errors.post_submission}
+        errors={errors.post_submission ? { confirmation_message: errors.post_submission } : undefined}
         touched={touched.post_submission}
         onBlur={() => onBlur('post_submission')}
       />

--- a/src/components/editors/FormsEditor/PostSubmissionConfig.tsx
+++ b/src/components/editors/FormsEditor/PostSubmissionConfig.tsx
@@ -15,7 +15,7 @@ import type { PostSubmissionConfig as PostSubmissionConfigType, PostSubmissionAc
 export interface PostSubmissionConfigProps {
   value?: PostSubmissionConfigType;
   onChange: (value?: PostSubmissionConfigType) => void;
-  errors?: any;
+  errors?: Record<string, string | undefined>;
   touched?: boolean;
   onBlur?: () => void;
 }
@@ -235,7 +235,7 @@ export const PostSubmissionConfig: React.FC<PostSubmissionConfigProps> = ({
                   <Select
                     label="Action Type"
                     value={action.action}
-                    onValueChange={(value) => handleUpdateAction(idx, { action: value as any })}
+                    onValueChange={(value) => handleUpdateAction(idx, { action: value as PostSubmissionAction['action'] })}
                     options={actionTypeOptions}
                     required
                   />

--- a/src/components/layout/ValidationPanel.tsx
+++ b/src/components/layout/ValidationPanel.tsx
@@ -13,7 +13,7 @@ import { useConfigStore } from '@/store';
 import { ValidationGroup } from './validation/ValidationGroup';
 import { ValidationEmptyState } from './validation/ValidationEmptyState';
 import type { ValidationError as StoreValidationError } from '@/store/types';
-import type { ValidationError, ValidationWarning } from '@/lib/validation/types';
+import type { ValidationError, ValidationWarning, EntityType } from '@/lib/validation/types';
 
 export interface ValidationPanelProps {
   /** Whether the panel is initially expanded */
@@ -108,7 +108,7 @@ export const ValidationPanel: React.FC<ValidationPanelProps> = ({
     });
 
     // Helper to determine entity type from entityId
-    const getEntityTypeFromId = (entityId: string): any => {
+    const getEntityTypeFromId = (entityId: string): EntityType => {
       // Try to infer from entity ID or default to 'config'
       if (entityId === 'global') return 'config';
       // For now, we'll need to look at the actual entities to determine type

--- a/src/components/modals/CreateTenantModal.tsx
+++ b/src/components/modals/CreateTenantModal.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui';
 import { createTenantSchema, type CreateTenantFormData } from '@/lib/schemas';
 import { configApiClient } from '@/lib/api/client';
+import type { TenantConfig } from '@/types/config';
 
 interface CreateTenantModalProps {
   open: boolean;
@@ -32,7 +33,7 @@ interface CreateTenantResponse {
   tenant_id: string;
   tenant_hash: string;
   embed_code: string;
-  config: any;
+  config: TenantConfig;
 }
 
 
@@ -186,7 +187,7 @@ export const CreateTenantModal: React.FC<CreateTenantModalProps> = ({ open, onCl
                 { value: 'Premium', label: 'Premium' },
               ]}
               value={subscriptionTier}
-              onValueChange={(value) => setValue('subscription_tier', value as any)}
+              onValueChange={(value) => setValue('subscription_tier', value as CreateTenantFormData['subscription_tier'])}
               error={errors.subscription_tier?.message}
             />
 

--- a/src/components/settings/AWSSettings.tsx
+++ b/src/components/settings/AWSSettings.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, Input, Badge } from '@/components/ui';
 import { useConfigStore } from '@/store';
-import type { AWSConfig } from '@/types/config';
+import type { AWSConfig, TenantConfig } from '@/types/config';
 import { Shield } from 'lucide-react';
 
 /**
@@ -25,23 +25,23 @@ export const AWSSettings: React.FC = () => {
   const baseConfig = useConfigStore((state) => state.config.baseConfig);
 
   // Update aws field
-  const updateAWS = (field: string, value: any) => {
+  const updateAWS = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
         if (!state.config.baseConfig.aws) {
-          state.config.baseConfig.aws = {} as any;
+          state.config.baseConfig.aws = {} as AWSConfig;
         }
-        (state.config.baseConfig.aws as any)[field] = value;
+        (state.config.baseConfig.aws as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });
   };
 
   // Update top-level baseConfig field
-  const updateBaseConfig = (field: string, value: any) => {
+  const updateBaseConfig = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
-        (state.config.baseConfig as any)[field] = value;
+        (state.config.baseConfig as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });
@@ -69,7 +69,7 @@ export const AWSSettings: React.FC = () => {
         {/* Bedrock Model ID */}
         <Input
           label="Bedrock Model ID"
-          value={(baseConfig as any)?.model_id || ''}
+          value={(baseConfig as TenantConfig & { model_id?: string })?.model_id || ''}
           onChange={(e) => updateBaseConfig('model_id', e.target.value)}
           placeholder="us.anthropic.claude-haiku-4-5-20251001-v1:0"
           helperText="Override the default Bedrock model for this tenant. Leave empty to use system default."

--- a/src/components/settings/BrandingSettings.tsx
+++ b/src/components/settings/BrandingSettings.tsx
@@ -26,13 +26,13 @@ export const BrandingSettings: React.FC = () => {
   const baseConfig = useConfigStore((state) => state.config.baseConfig);
 
   // Update branding field
-  const updateBranding = (field: string, value: any) => {
+  const updateBranding = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
         if (!state.config.baseConfig.branding) {
-          state.config.baseConfig.branding = {} as any;
+          state.config.baseConfig.branding = {} as BrandingConfig;
         }
-        (state.config.baseConfig.branding as any)[field] = value;
+        (state.config.baseConfig.branding as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });

--- a/src/components/settings/FeaturesSettings.tsx
+++ b/src/components/settings/FeaturesSettings.tsx
@@ -51,29 +51,29 @@ export const FeaturesSettings: React.FC = () => {
   const baseConfig = useConfigStore((state) => state.config.baseConfig);
 
   // Update features field
-  const updateFeatures = (field: string, value: any) => {
+  const updateFeatures = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
         if (!state.config.baseConfig.features) {
-          state.config.baseConfig.features = {} as any;
+          state.config.baseConfig.features = {} as FeaturesConfig;
         }
-        (state.config.baseConfig.features as any)[field] = value;
+        (state.config.baseConfig.features as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });
   };
 
   // Update callout sub-field
-  const updateCallout = (field: string, value: any) => {
+  const updateCallout = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
         if (!state.config.baseConfig.features) {
-          state.config.baseConfig.features = {} as any;
+          state.config.baseConfig.features = {} as FeaturesConfig;
         }
         if (!state.config.baseConfig.features.callout) {
-          state.config.baseConfig.features.callout = {} as any;
+          state.config.baseConfig.features.callout = {} as CalloutConfig;
         }
-        (state.config.baseConfig.features.callout as any)[field] = value;
+        (state.config.baseConfig.features.callout as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });
@@ -84,7 +84,7 @@ export const FeaturesSettings: React.FC = () => {
 
   // Helper to bind a feature flag to FeatureToggle's checked/onChange props
   const flag = (field: string) => ({
-    checked: !!(features as any)[field],
+    checked: !!(features as Record<string, unknown>)[field],
     onChange: (v: boolean) => updateFeatures(field, v),
   });
 

--- a/src/components/settings/IntegrationSettings.tsx
+++ b/src/components/settings/IntegrationSettings.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, Input } from '@/components/ui';
 import { useConfigStore } from '@/store';
+import type { TenantConfig } from '@/types/config';
 
 /**
  * Integration Settings Component
@@ -22,16 +23,21 @@ import { useConfigStore } from '@/store';
 export const IntegrationSettings: React.FC = () => {
   const baseConfig = useConfigStore((state) => state.config.baseConfig);
 
-  const webhookUrl = (baseConfig as any)?.bubble_integration?.webhook_url ?? '';
-  const apiKey = (baseConfig as any)?.bubble_integration?.api_key ?? '';
+  // bubble_integration is a legacy passthrough not in TenantConfig's typed surface
+  type ConfigWithBubble = TenantConfig & {
+    bubble_integration?: { webhook_url?: string; api_key?: string; [k: string]: unknown };
+  };
+  const webhookUrl = (baseConfig as ConfigWithBubble | null)?.bubble_integration?.webhook_url ?? '';
+  const apiKey = (baseConfig as ConfigWithBubble | null)?.bubble_integration?.api_key ?? '';
 
   const updateField = (field: string, value: string) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
-        if (!(state.config.baseConfig as any).bubble_integration) {
-          (state.config.baseConfig as any).bubble_integration = {};
+        const cfg = state.config.baseConfig as ConfigWithBubble;
+        if (!cfg.bubble_integration) {
+          cfg.bubble_integration = {};
         }
-        (state.config.baseConfig as any).bubble_integration[field] = value;
+        cfg.bubble_integration[field] = value;
         state.config.isDirty = true;
       }
     });

--- a/src/components/settings/QuickHelpSettings.tsx
+++ b/src/components/settings/QuickHelpSettings.tsx
@@ -29,13 +29,13 @@ export const QuickHelpSettings: React.FC = () => {
   const [newPrompt, setNewPrompt] = useState('');
 
   // Update quick_help field
-  const updateQuickHelp = (field: string, value: any) => {
+  const updateQuickHelp = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
         if (!state.config.baseConfig.quick_help) {
-          state.config.baseConfig.quick_help = {} as any;
+          state.config.baseConfig.quick_help = {} as QuickHelpConfig;
         }
-        (state.config.baseConfig.quick_help as any)[field] = value;
+        (state.config.baseConfig.quick_help as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });

--- a/src/components/settings/TenantIdentitySettings.tsx
+++ b/src/components/settings/TenantIdentitySettings.tsx
@@ -25,10 +25,10 @@ export const TenantIdentitySettings: React.FC = () => {
   const baseConfig = useConfigStore((state) => state.config.baseConfig);
 
   // Update field in baseConfig
-  const updateField = (field: string, value: any) => {
+  const updateField = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
-        (state.config.baseConfig as any)[field] = value;
+        (state.config.baseConfig as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });

--- a/src/components/settings/WidgetBehaviorSettings.tsx
+++ b/src/components/settings/WidgetBehaviorSettings.tsx
@@ -25,13 +25,13 @@ export const WidgetBehaviorSettings: React.FC = () => {
   const baseConfig = useConfigStore((state) => state.config.baseConfig);
 
   // Update widget_behavior field
-  const updateWidgetBehavior = (field: string, value: any) => {
+  const updateWidgetBehavior = (field: string, value: unknown) => {
     useConfigStore.setState((state) => {
       if (state.config.baseConfig) {
         if (!state.config.baseConfig.widget_behavior) {
-          state.config.baseConfig.widget_behavior = {} as any;
+          state.config.baseConfig.widget_behavior = {} as WidgetBehaviorConfig;
         }
-        (state.config.baseConfig.widget_behavior as any)[field] = value;
+        (state.config.baseConfig.widget_behavior as Record<string, unknown>)[field] = value;
         state.config.isDirty = true;
       }
     });
@@ -122,12 +122,15 @@ export const WidgetBehaviorSettings: React.FC = () => {
                   useConfigStore.setState((state) => {
                     if (state.config.baseConfig) {
                       if (!state.config.baseConfig.widget_behavior) {
-                        state.config.baseConfig.widget_behavior = {} as any;
+                        state.config.baseConfig.widget_behavior = {} as WidgetBehaviorConfig;
                       }
-                      if (!state.config.baseConfig.widget_behavior!.mobile) {
-                        (state.config.baseConfig.widget_behavior as any).mobile = {};
+                      const wb = state.config.baseConfig.widget_behavior as WidgetBehaviorConfig & {
+                        mobile?: { start_open?: boolean };
+                      };
+                      if (!wb.mobile) {
+                        wb.mobile = {};
                       }
-                      (state.config.baseConfig.widget_behavior as any).mobile.start_open = e.target.checked;
+                      wb.mobile.start_open = e.target.checked;
                       state.config.isDirty = true;
                     }
                   });

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useRef } from 'react';
 import { useConfigStore } from '@/store';
+import type { ConversationalForm } from '@/types/config';
 
 export interface AutoSaveOptions {
   /**
@@ -122,7 +123,7 @@ export function useAutoSave(options: AutoSaveOptions = {}) {
           state.forms.forms = Object.fromEntries(
             Object.entries(autoSaveData.forms).map(([key, form]) => [
               key,
-              { ...(form as any), form_id: key } // Override form_id to match the key
+              { ...(form as ConversationalForm), form_id: key } // Override form_id to match the key
             ])
           );
         }

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -41,7 +41,7 @@ export class ConfigAPIError extends Error {
 
     // Maintain proper stack trace for where our error was thrown (only available on V8)
     const ErrorWithCapture = Error as ErrorConstructor & {
-      captureStackTrace?: (target: object, ctor: Function) => void;
+      captureStackTrace?: (target: object, ctor: new (...args: unknown[]) => unknown) => void;
     };
     if (typeof ErrorWithCapture.captureStackTrace === 'function') {
       ErrorWithCapture.captureStackTrace(this, ConfigAPIError);


### PR DESCRIPTION
## Summary

Knocks out all 46 `no-explicit-any` violations in `src/components/` + `src/hooks/`, plus 1 bonus Function-type fix in `src/lib/api/errors.ts`. **Lint baseline: 60 → 13 (-47).**

🎉 **Phase C complete — all 148 anys cleared across the codebase.** The remaining 13 problems are entirely the B3 deferred set (12 `react-hooks/set-state-in-effect` + 1 coupled `exhaustive-deps` in `ValidationPanel.tsx`, tracked in issue #30).

## Changes

### Settings cluster (7 files, 33 anys)
All followed the same pattern: `updateX(field: string, value: any)` + `state.config.baseConfig.X = {} as any` + `(state.config.baseConfig.X as any)[field] = value`. Mechanical fix:
- `value: any` → `value: unknown`
- `{} as any` → `{} as <NamedSliceType>` (FeaturesConfig, AWSConfig, BrandingConfig, etc.)
- `(X as any)[field]` → `(X as Record<string, unknown>)[field]`

Plus three special cases:
- `IntegrationSettings.tsx`: local `ConfigWithBubble` type for the `bubble_integration` legacy passthrough (not in `TenantConfig`)
- `AWSSettings.tsx`: `(baseConfig as any).model_id` → typed cast `TenantConfig & { model_id?: string }`
- `FeaturesSettings.tsx`: the `flag(field)` helper from #28 — dynamic-key read kept, typed via `Record<string, unknown>`

### Other components (9 files, 12 anys)

| File | Fix |
|---|---|
| `TenantSelector.tsx` | `tenant: any` → `TenantListItem` |
| `dashboard/ConversationFlowDiagram.tsx` | `entities: any[]` → `Array<{ id; label; type? }>` |
| `dashboard/types.ts` | `metadata: Record<string, any>` → `Record<string, unknown>` |
| `deploy/DeployButton.tsx` | `mergedConfig as any` → `as TenantConfig` |
| `BranchesEditor.tsx` | `context: any` → `ValidationContext<BranchEntity>` |
| `CTAEditor/CTAForm.tsx` | `(cta as any).style` ×2 → `(cta as CTADefinition & { style?: CTAStyle }).style` for the deprecated v1.5 field |
| `FormsEditor/PostSubmissionConfig.tsx` | `errors: any` → `Record<string, string \| undefined>`; `value as any` → `as PostSubmissionAction['action']` |
| `layout/ValidationPanel.tsx` | `getEntityTypeFromId(): any` → `: EntityType` |
| `modals/CreateTenantModal.tsx` | `config: any` → `TenantConfig`; `setValue value as any` → `as CreateTenantFormData['subscription_tier']` |

### Hooks (1 file, 1 any)
`useAutoSave.ts`: `(form as any)` → `(form as ConversationalForm)` in loadFromStorage form-id normalization.

### Cascade fix (1 file)
`FormsEditor/FormFormFields.tsx`: `PostSubmissionConfig` now expects `Record<string, string | undefined>` for errors. Parent was passing `errors.post_submission` (a string). The original `any` typing **hid this real mismatch** — now wrapped as `{ confirmation_message: errors.post_submission }` to match the child's read pattern.

### Bonus (1 file, 1 violation)
`lib/api/errors.ts`: my Phase C2 `captureStackTrace` fix used `Function` as a callback type, which violates `@typescript-eslint/no-unsafe-function-type`. Replaced with `new (...args: unknown[]) => unknown`.

## Verification

- [x] `npm run lint`: 60 → 13 problems (all anys cleared, B3 deferred set remaining)
- [x] `npm run typecheck`: clean
- [x] `npm run test:run`: 437/437 passing

### Test-coverage gaps (waived — same pattern as prior PRs)

Settings components have no direct unit tests (pre-existing). The FormFormFields cascade fix exposed a long-hidden type mismatch that `any` was masking — runtime behavior is unchanged.

## What's left

| Phase | Rules | Count |
|---|---|---|
| **B3 (issue #30)** | `react-hooks/set-state-in-effect` ×12 + ValidationPanel coupled `exhaustive-deps` ×1 | 13 |
| **Final** | Flip `continue-on-error: true` → `false` on lint job | — |
| | _Total remaining_ | **13** |

Once B3 lands, a final tiny PR flips the lint gate to required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)