### PR TITLE
ci: promote lint to required gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,13 +11,8 @@ env:
 
 jobs:
   lint:
-    # TODO(lint-cleanup): Flip continue-on-error to false once the ESLint
-    # debt cleanup PR lands. ESLint has never been configured in this repo;
-    # enabling it surfaces ~200 pre-existing problems that are being
-    # cleaned up on a separate branch (feat/lint-cleanup-phase-a).
     name: Code Quality - Linting
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The full ESLint debt cleanup chain has now landed (PRs #26–#35) and `npm run lint` exits clean on main. Drops `continue-on-error: true` from the lint job in `pr-checks.yml` and removes the now-stale `TODO(lint-cleanup):` comment, so future regressions block PRs.

Mirrors the pattern from #25 (typecheck promotion).

## Changes

`pr-checks.yml`:
- Remove `continue-on-error: true` from the `lint` job
- Remove the `TODO(lint-cleanup):` comment block

`deploy-production.yml`: **no changes needed** — its lint job already runs without `continue-on-error`, and lint is already in `needs: [lint, typecheck, test]` for both `build` and `deploy-production-staging`.

## Verification

- [x] `npm run lint` on main: clean (zero problems)
- [x] Diff is a single 5-line deletion in one workflow file
- [x] Mirrors the structure of #25's typecheck promotion

## Branch protection

Branch protection on main needs `Code Quality - Linting` added to the required status checks list — same manual follow-up done after #25 for typecheck.

## Cleanup chain summary

| Phase | PR | Net |
|---|---|---|
| Config landing | #26 | baseline 233 |
| A — mechanical | #27 | -45 |
| B1 — static-components | #28 | -17 |
| B2 — react-hooks correctness | #29 | -10 |
| C1 — test anys | #31 | -55 |
| C2 — lib anys | #32 | -32 |
| C3 — store anys | #33 | -14 |
| C4 — UI anys | #34 | -47 |
| B3 — set-state-in-effect | #35 | -15 |
| **This PR — flip gate to required** | **#36** | — |
| | | **Total: 235 → 0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)