### PR TITLE
ci: promote lint to required gate in deploy-production.yml

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,10 +18,8 @@ env:
 
 jobs:
   lint:
-    # See pr-checks.yml — same lint debt deferral applies on main pushes.
     name: Code Quality - Linting
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -123,7 +121,7 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: [typecheck, test, security, build]
+    needs: [lint, typecheck, test, security, build]
     runs-on: ubuntu-latest
     environment: production
     permissions:


### PR DESCRIPTION
## Summary

PR #36 promoted lint to a required gate but only updated \`pr-checks.yml\` — \`deploy-production.yml\` still had \`continue-on-error: true\` on the lint job and didn't include lint in \`deploy-production\`'s \`needs:\` chain. This PR closes that gap so the main-push pipeline matches the PR pipeline.

## Verification

- \`npm run lint\` clean on main locally (exit 0)

## Follow-up after merge

Branch protection on \`main\` gets \`Code Quality - Linting\` added to required status checks. All five gates will then be hard gates with no \`continue-on-error\` remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)