### PR TITLE
fix(build): default VITE_CLERK_PUBLISHABLE_KEY to production pk_live

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -127,7 +127,10 @@ const defineVars = {
   'import.meta.env.VITE_S3_BUCKET': JSON.stringify(process.env.VITE_S3_BUCKET || 'myrecruiter-picasso'),
   'import.meta.env.VITE_AWS_REGION': JSON.stringify(process.env.VITE_AWS_REGION || 'us-east-1'),
   'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || ''),
-  'import.meta.env.VITE_CLERK_PUBLISHABLE_KEY': JSON.stringify(process.env.VITE_CLERK_PUBLISHABLE_KEY || ''),
+  // Clerk publishable keys are designed to be public (they ship in the browser
+  // bundle by design). Hardcoding the production key as a default keeps CI
+  // builds working without an extra Secret/env-var configuration step.
+  'import.meta.env.VITE_CLERK_PUBLISHABLE_KEY': JSON.stringify(process.env.VITE_CLERK_PUBLISHABLE_KEY || 'pk_live_Y2xlcmsuY29uZmlnLm15cmVjcnVpdGVyLmFpJA'),
   'import.meta.env.VITE_CHANNELS_API_URL': JSON.stringify(process.env.VITE_CHANNELS_API_URL || ''),
 
   // Node.js environment compatibility


### PR DESCRIPTION
## Summary
Production Config Builder at https://config.myrecruiter.ai renders a blank dark page because the Clerk SDK never initializes:

- `#root` is empty after page load
- `window.Clerk` is undefined
- Zero network requests to `clerk.config.myrecruiter.ai` or `*.clerk.com`
- Console only shows the harmless zustand devtools warning

**Cause:** CI's Build for production step doesn't set `VITE_CLERK_PUBLISHABLE_KEY`. Our Vite-style env shim in `esbuild.config.mjs` falls back to `''` when the env var is unset, so the bundled `clerkKey` resolves to `''`. `<ClerkProvider publishableKey="">` throws silently and leaves the root unrendered.

**Verified by inspecting the deployed bundle:** `curl -s https://config.myrecruiter.ai/main.js | grep -oE 'pk_(test|live)_[A-Za-z0-9]+'` returns nothing.

## Fix
Add the production `pk_live_` as the default fallback in `esbuild.config.mjs`. Matches the existing pattern used for `VITE_S3_BUCKET` and `VITE_AWS_REGION` in the same file.

```js
'import.meta.env.VITE_CLERK_PUBLISHABLE_KEY': JSON.stringify(
  process.env.VITE_CLERK_PUBLISHABLE_KEY ||
  'pk_live_Y2xlcmsuY29uZmlnLm15cmVjcnVpdGVyLmFpJA'
),
```

**Why hardcoding is safe:** Clerk publishable keys (`pk_test_*` / `pk_live_*`) are designed to be public — they identify the Clerk frontend instance and ship in the browser bundle by design. Authorization is enforced server-side via the **secret key** (`sk_live_*`) on Lambdas + JWT signature verification with JWKS. The Picasso widget already ships its own `pk` in plaintext via `chat.myrecruiter.ai/widget.js`.

DNS for `clerk.config.myrecruiter.ai` is already configured (resolves to Clerk's `frontend-api.clerk.services` via Cloudflare).

## Test plan
- [x] `npm run build:production` completes locally; `grep -oE 'pk_(live|test)_[A-Za-z0-9]+' dist/main.js` returns `pk_live_Y2xlcmsuY29uZmlnLm15cmVjcnVpdGVyLmFpJA`
- [ ] Post-merge: CI deploys to S3 `picasso-config-builder-prod`, loading https://config.myrecruiter.ai shows the Clerk sign-in UI instead of a blank page
- [ ] Network tab confirms a request to `https://clerk.config.myrecruiter.ai/v1/client?...` after the fix lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)