### PR TITLE
chore(deps): bump @clerk/react past CVE GHSA-w24r-5266-9c3c

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,12 +1434,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.2.0.tgz",
-      "integrity": "sha512-+w8/5byq8qJuCABXHzO4TRZbM+QVsODBBBQN2EWb9E4KX52YCyoVeEOB6C4QOhLCJtd0VwJsAPO/H9Mjn3XlrA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.5.0.tgz",
+      "integrity": "sha512-TXYxlJ9EvPvJo6NKTy//RlqoZ4nhvmIjlU9cp9KG3buHD7UCby0It9dtaPHbAu5h4s426C7F6GID47LolaLEbg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.5.0",
+        "@clerk/shared": "^4.9.0",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -1451,13 +1451,13 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.8.6",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.6.tgz",
-      "integrity": "sha512-IItiQftnKaY928Q/DNOWA+32WCoKk/YwpFPOrU46P7gz+FU6O3KR8YGyTO6K+/YLG8LNB7zqBJY7t24GSwoNHA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.9.0.tgz",
+      "integrity": "sha512-YU9Fv6FK1EwxM7uz1hGPrLpvcHRhHm8Quuh5RL343oXakE+/JHtYy4OhwVgqYVA+j63pw+7lpghL3CYQTgk0hA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "^5.90.16",
+        "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -4527,9 +4527,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.16",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
-      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "version": "5.100.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.7.tgz",
+      "integrity": "sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==",
       "license": "MIT",
       "funding": {
         "type": "github",


### PR DESCRIPTION
## Summary
`@clerk/react` 6.0.0-6.4.2 carries [GHSA-w24r-5266-9c3c](https://github.com/advisories/GHSA-w24r-5266-9c3c) — a high-severity authorization bypass when combining organization, billing, or reverification checks. The advisory landed after main's last green CI run, and is now blocking [#39](https://github.com/longhornrumble/picasso-config-builder/pull/39) (the Clerk publishable-key fix) in the Security Audit step.

`npm audit fix` bumps the lockfile to 6.5.0 — non-breaking, no `package.json` change required.

## Test plan
- [x] `npm run build:production` — succeeds
- [x] `npm run test:run` — 29 test files, 452 tests passed
- [x] `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities (exact CI command)

Lockfile-only diff. Once merged, PR #39's CI re-runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)