### PR TITLE
ci: invalidate CloudFront on production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,6 +15,7 @@ env:
   NODE_VERSION: '22'
   AWS_REGION: 'us-east-1'
   S3_BUCKET_PRODUCTION: 'picasso-config-builder-prod'
+  CLOUDFRONT_DISTRIBUTION_ID: 'E3OTEE0UFN347Y'
 
 jobs:
   lint:
@@ -142,3 +143,13 @@ jobs:
 
       - name: Deploy to production S3
         run: aws s3 sync dist/ s3://${{ env.S3_BUCKET_PRODUCTION }}/ --delete
+
+      # CloudFront caches main.js etc. at edge POPs. Without invalidation,
+      # browsers continue serving the previous bundle until the configured
+      # TTL expires (can be hours). Invalidate /* so the new deploy is
+      # immediately visible to all users.
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"


### PR DESCRIPTION
## Summary
The deploy workflow syncs to S3 but does not invalidate CloudFront. After PR #39 merged, the bundle deployed to S3 immediately, but `https://config.myrecruiter.ai/main.js` continued returning the previous bundle from edge POPs that cached it. Symptom: terminal `curl` saw the new bundle (different POP), but a browser session saw the old one until the distribution was manually invalidated.

## Change
Add `cloudfront:CreateInvalidation` step to the `deploy-production` job, plus the distribution ID as a workflow env var (matching the existing `S3_BUCKET_PRODUCTION` pattern).

```yaml
env:
  ...
  CLOUDFRONT_DISTRIBUTION_ID: 'E3OTEE0UFN347Y'

jobs:
  deploy-production:
    steps:
      ...
      - name: Deploy to production S3
        run: aws s3 sync dist/ s3://${{ env.S3_BUCKET_PRODUCTION }}/ --delete

      - name: Invalidate CloudFront cache
        run: |
          aws cloudfront create-invalidation \
            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
            --paths "/*"
```

## ⚠️ IAM permission assumption
The `AWS_DEPLOY_ROLE_ARN` role needs `cloudfront:CreateInvalidation` on `E3OTEE0UFN347Y`. I haven't verified the role's policy. If the permission is missing, the next deploy fails on this step with `AccessDenied` — visible immediately in the workflow log; fix is to add the IAM action.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-production.yml'))"` — YAML parses
- [ ] After merge, next push to `main` runs the workflow and the Invalidate step succeeds
- [ ] If Invalidate step fails with `AccessDenied`, file a follow-up to add `cloudfront:CreateInvalidation` to the deploy role policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)