### PR TITLE
fix(build): default VITE_API_URL to production Lambda URL

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -126,7 +126,11 @@ const defineVars = {
   'import.meta.env.MODE': JSON.stringify(environment),
   'import.meta.env.VITE_S3_BUCKET': JSON.stringify(process.env.VITE_S3_BUCKET || 'myrecruiter-picasso'),
   'import.meta.env.VITE_AWS_REGION': JSON.stringify(process.env.VITE_AWS_REGION || 'us-east-1'),
-  'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || ''),
+  // Production Lambda Function URL for the Config Manager API. Hardcoded as
+  // the default so CI builds work without an explicit VITE_API_URL secret. The
+  // empty-string fallback shipped to production with the placeholder
+  // 'api.yourapi.com' baked into client.ts, breaking tenant loads.
+  'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'https://56mwo4zatkiqzpancrkkzqr43e0nkrui.lambda-url.us-east-1.on.aws'),
   // Clerk publishable keys are designed to be public (they ship in the browser
   // bundle by design). Hardcoding the production key as a default keeps CI
   // builds working without an extra Secret/env-var configuration step.


### PR DESCRIPTION
## Summary
Same failure pattern as [#39](https://github.com/longhornrumble/picasso-config-builder/pull/39) (Clerk publishable key). `VITE_API_URL` is unset in CI's build environment, so the bundled value resolves to `''`. The fallback in `src/lib/api/client.ts` then uses the placeholder URL `https://api.yourapi.com/api`, causing every config API call from production https://config.myrecruiter.ai to fail at the DNS layer with no Lambda invocation.

**Symptom:** "Failed to load tenants" toast on page load. Confirmed no logs in `/aws/lambda/Picasso_Config_Manager` during the failing window — Lambda was never being invoked.

**Root cause from `src/lib/api/client.ts:19`:**
```ts
const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://api.yourapi.com/api';
```

## Fix
Hardcode the production Lambda Function URL as the default in `esbuild.config.mjs`. Matches the pattern set by #39 for the Clerk key. No `/api` suffix — Picasso_Config_Manager routes are `/config/tenants` directly.

```js
'import.meta.env.VITE_API_URL': JSON.stringify(
  process.env.VITE_API_URL ||
  'https://56mwo4zatkiqzpancrkkzqr43e0nkrui.lambda-url.us-east-1.on.aws'
),
```

## Test plan
- [x] `npm run build:production`: Lambda URL grep'd in `dist/main.js`; placeholder `api.yourapi.com` dead-code-eliminated
- [ ] After merge: CI builds + deploys + auto-invalidates CloudFront (#41); reload https://config.myrecruiter.ai shows real tenant list instead of error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)