### PR TITLE
feat(scheduling): wire scheduling block + 6 cross-section invariants in tenant.schema (A5)

### DIFF
--- a/src/lib/schemas/__tests__/tenant.schema.scheduling.test.ts
+++ b/src/lib/schemas/__tests__/tenant.schema.scheduling.test.ts
@@ -1,0 +1,234 @@
+/**
+ * tenant.schema.ts scheduling cross-section invariants (sub-phase A5).
+ *
+ * Spec source: scheduling/docs/scheduling_config_schema.md §10. Each test
+ * exercises one of the 6 invariants; baselines confirm a valid scheduling
+ * config still passes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tenantConfigSchema } from '../tenant.schema';
+
+// ============================================================================
+// Helpers — minimal valid tenant config + scheduling block
+// ============================================================================
+
+const baseTenant = () => ({
+  tenant_id: 'TEST123',
+  tenant_hash: 'abc123def456',
+  subscription_tier: 'Standard' as const,
+  chat_title: 'Test Bot',
+  tone_prompt: 'You are a helpful assistant.',
+  welcome_message: 'Hello!',
+  version: '1.5',
+  generated_at: 1700000000,
+  conversational_forms: {},
+  cta_definitions: {},
+  conversation_branches: {},
+  branding: {
+    primary_color: '#00AA88',
+    font_family: 'Inter',
+  },
+  features: {
+    uploads: false,
+    photo_uploads: false,
+    voice_input: false,
+    streaming: true,
+    conversational_forms: false,
+    smart_cards: false,
+    callout: { enabled: false, auto_dismiss: false },
+  },
+  aws: {
+    knowledge_base_id: 'KBABCDEFGH12',
+    aws_region: 'us-east-1',
+  },
+  channels: undefined,
+});
+
+const validScheduling = () => ({
+  workspace_domains: ['myrecruiter.ai'],
+  default_locale: 'en',
+  available_locales: ['en'],
+  scheduling_tag_vocabulary: ['program', 'language'],
+  appointment_types: {
+    volunteer_intake: {
+      id: 'volunteer_intake',
+      name: 'Volunteer intake call',
+      duration_minutes: 20,
+      location_mode: 'virtual_meet' as const,
+      routing_policy_id: 'volunteer_pool',
+    },
+  },
+  routing_policies: {
+    volunteer_pool: {
+      id: 'volunteer_pool',
+      tag_conditions: [
+        { tag: 'program', operator: 'equals' as const, values: ['weekend_food_pantry'] },
+      ],
+    },
+  },
+});
+
+// ============================================================================
+// Baseline
+// ============================================================================
+
+describe('tenantConfigSchema — scheduling baseline', () => {
+  it('accepts a tenant with scheduling_enabled and a fully wired scheduling block', () => {
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+      scheduling: validScheduling(),
+    };
+    expect(() => tenantConfigSchema.parse(config)).not.toThrow();
+  });
+
+  it('accepts a tenant with no scheduling block when scheduling_enabled is absent', () => {
+    expect(() => tenantConfigSchema.parse(baseTenant())).not.toThrow();
+  });
+});
+
+// ============================================================================
+// §10 Invariants 1–6
+// ============================================================================
+
+describe('tenantConfigSchema — scheduling invariants (§10)', () => {
+  it('Invariant 1: scheduling_enabled without scheduling block is rejected', () => {
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+    };
+    expect(() => tenantConfigSchema.parse(config)).toThrow(
+      /scheduling_enabled requires a scheduling configuration block/,
+    );
+  });
+
+  it('Invariant 2: appointment_type with unknown routing_policy_id is rejected', () => {
+    const scheduling = validScheduling();
+    scheduling.appointment_types.volunteer_intake.routing_policy_id = 'ghost_pool';
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+      scheduling,
+    };
+    expect(() => tenantConfigSchema.parse(config)).toThrow(
+      /references non-existent routing_policy: ghost_pool/,
+    );
+  });
+
+  it('Invariant 3: routing_policy with tag outside vocabulary is rejected', () => {
+    const scheduling = validScheduling();
+    scheduling.routing_policies.volunteer_pool.tag_conditions = [
+      { tag: 'unregistered_tag', operator: 'equals', values: ['x'] },
+    ];
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+      scheduling,
+    };
+    expect(() => tenantConfigSchema.parse(config)).toThrow(
+      /references unknown tag: unregistered_tag/,
+    );
+  });
+
+  it('Invariant 4: pre_call_form_id pointing at non-existent form is rejected', () => {
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+      scheduling: {
+        ...validScheduling(),
+        pre_call_form_id: 'missing_form',
+      },
+    };
+    expect(() => tenantConfigSchema.parse(config)).toThrow(
+      /pre_call_form_id references non-existent form: missing_form/,
+    );
+  });
+
+  it('Invariant 5: default_locale not in available_locales is rejected', () => {
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+      scheduling: {
+        ...validScheduling(),
+        default_locale: 'es',
+        available_locales: ['en'],
+      },
+    };
+    expect(() => tenantConfigSchema.parse(config)).toThrow(
+      /default_locale.*es.*is not in available_locales/,
+    );
+  });
+
+  it('Invariant 6a: scheduling CTA without scheduling_enabled is rejected', () => {
+    const config = {
+      ...baseTenant(),
+      cta_definitions: {
+        book_call: {
+          label: 'Book a call',
+          action: 'start_scheduling',
+          type: 'scheduling_trigger',
+        },
+      },
+    };
+    expect(() => tenantConfigSchema.parse(config)).toThrow(
+      /requires feature_flags\.scheduling_enabled === true/,
+    );
+  });
+
+  it('Invariant 6b: scheduling CTA with empty appointment_types is rejected', () => {
+    const scheduling = validScheduling();
+    scheduling.appointment_types = {};
+    // Routing policy still references a tag in vocabulary, so we keep policies empty too
+    scheduling.routing_policies = {};
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+      scheduling,
+      cta_definitions: {
+        book_call: {
+          label: 'Book a call',
+          action: 'resume_scheduling',
+          type: 'scheduling_trigger',
+        },
+      },
+    };
+    expect(() => tenantConfigSchema.parse(config)).toThrow(
+      /requires non-empty scheduling\.appointment_types/,
+    );
+  });
+
+  it('Invariant 6 (positive): scheduling CTA accepted when both gates satisfied', () => {
+    const config = {
+      ...baseTenant(),
+      feature_flags: { scheduling_enabled: true },
+      scheduling: validScheduling(),
+      cta_definitions: {
+        book_call: {
+          label: 'Book a call',
+          action: 'start_scheduling',
+          type: 'scheduling_trigger',
+        },
+      },
+    };
+    expect(() => tenantConfigSchema.parse(config)).not.toThrow();
+  });
+});
+
+// ============================================================================
+// Passthrough: existing feature_flags coexist with scheduling_enabled
+// ============================================================================
+
+describe('tenantConfigSchema — feature_flags passthrough', () => {
+  it('accepts unknown feature flags alongside scheduling_enabled', () => {
+    const config = {
+      ...baseTenant(),
+      feature_flags: {
+        scheduling_enabled: false,
+        V4_ACTION_SELECTOR: true,
+        DYNAMIC_CHIPS: true,
+      },
+    };
+    expect(() => tenantConfigSchema.parse(config)).not.toThrow();
+  });
+});

--- a/src/lib/schemas/tenant.schema.ts
+++ b/src/lib/schemas/tenant.schema.ts
@@ -7,6 +7,7 @@ import { programSchema } from './program.schema';
 import { conversationalFormSchema } from './form.schema';
 import { ctaDefinitionSchema } from './cta.schema';
 import { conversationBranchSchema } from './branch.schema';
+import { schedulingConfigSchema } from './scheduling.schema';
 
 // ============================================================================
 // BRANDING SCHEMA
@@ -222,6 +223,19 @@ export const channelsConfigSchema = z
   .optional();
 
 // ============================================================================
+// FEATURE FLAGS SCHEMA
+// ============================================================================
+
+// Passthrough so existing flags (V4_ACTION_SELECTOR, DYNAMIC_ACTIONS, etc.)
+// remain valid without listing them all here. Only fields whose values gate
+// other invariants (per scheduling_config_schema §1) are typed.
+export const featureFlagsSchema = z
+  .object({
+    scheduling_enabled: z.boolean().optional().default(false),
+  })
+  .passthrough();
+
+// ============================================================================
 // FULL TENANT CONFIG SCHEMA
 // ============================================================================
 
@@ -258,6 +272,10 @@ export const tenantConfigSchema = z.object({
 
   // Channel integrations
   channels: channelsConfigSchema,
+
+  // Scheduling (optional v1 block — schema spec §1)
+  scheduling: schedulingConfigSchema.optional(),
+  feature_flags: featureFlagsSchema.optional(),
 
 }).superRefine((data, ctx) => {
   // Validate feature dependencies
@@ -334,6 +352,97 @@ export const tenantConfigSchema = z.object({
     });
   });
 
+  // ==========================================================================
+  // Scheduling cross-section invariants (schema spec §10)
+  // ==========================================================================
+
+  const schedulingEnabled = data.feature_flags?.scheduling_enabled === true;
+
+  // Invariant 1: scheduling_enabled === true ⟹ scheduling block present
+  if (schedulingEnabled && !data.scheduling) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['scheduling'],
+      message: 'scheduling_enabled requires a scheduling configuration block',
+    });
+  }
+
+  if (data.scheduling) {
+    const scheduling = data.scheduling;
+    const routingPolicyIds = new Set(Object.keys(scheduling.routing_policies ?? {}));
+    const tagVocabulary = new Set(scheduling.scheduling_tag_vocabulary ?? []);
+
+    // Invariant 2: every appointment_types[*].routing_policy_id ∈ routing_policies
+    Object.entries(scheduling.appointment_types ?? {}).forEach(([typeId, appt]) => {
+      if (!routingPolicyIds.has(appt.routing_policy_id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['scheduling', 'appointment_types', typeId, 'routing_policy_id'],
+          message: `Appointment type references non-existent routing_policy: ${appt.routing_policy_id}`,
+        });
+      }
+    });
+
+    // Invariant 3: every routing_policies[*].tag_conditions[*].tag ∈ scheduling_tag_vocabulary
+    Object.entries(scheduling.routing_policies ?? {}).forEach(([policyId, policy]) => {
+      (policy.tag_conditions ?? []).forEach((condition, index) => {
+        if (!tagVocabulary.has(condition.tag)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['scheduling', 'routing_policies', policyId, 'tag_conditions', index, 'tag'],
+            message: `Tag condition references unknown tag: ${condition.tag}`,
+          });
+        }
+      });
+    });
+
+    // Invariant 4: scheduling.pre_call_form_id, when set, ∈ conversational_forms
+    if (scheduling.pre_call_form_id && !data.conversational_forms[scheduling.pre_call_form_id]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['scheduling', 'pre_call_form_id'],
+        message: `pre_call_form_id references non-existent form: ${scheduling.pre_call_form_id}`,
+      });
+    }
+
+    // Invariant 5: scheduling.default_locale ∈ scheduling.available_locales
+    if (
+      scheduling.default_locale &&
+      Array.isArray(scheduling.available_locales) &&
+      !scheduling.available_locales.includes(scheduling.default_locale)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['scheduling', 'default_locale'],
+        message: `default_locale "${scheduling.default_locale}" is not in available_locales`,
+      });
+    }
+  }
+
+  // Invariant 6: every CTA with action ∈ {start_scheduling, resume_scheduling}
+  // requires scheduling_enabled === true and non-empty scheduling.appointment_types
+  const hasAppointmentTypes =
+    !!data.scheduling && Object.keys(data.scheduling.appointment_types ?? {}).length > 0;
+
+  Object.entries(data.cta_definitions).forEach(([ctaId, cta]) => {
+    if (cta.action === 'start_scheduling' || cta.action === 'resume_scheduling') {
+      if (!schedulingEnabled) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['cta_definitions', ctaId, 'action'],
+          message: `CTA action "${cta.action}" requires feature_flags.scheduling_enabled === true`,
+        });
+      }
+      if (!hasAppointmentTypes) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['cta_definitions', ctaId, 'action'],
+          message: `CTA action "${cta.action}" requires non-empty scheduling.appointment_types`,
+        });
+      }
+    }
+  });
+
 });
 
 // ============================================================================
@@ -358,3 +467,4 @@ export type TenantConfig = z.infer<typeof tenantConfigSchema>;
 export type ChannelConnection = z.infer<typeof channelConnectionSchema>;
 export type InstagramChannelConnection = z.infer<typeof instagramChannelConnectionSchema>;
 export type ChannelsConfig = z.infer<typeof channelsConfigSchema>;
+export type FeatureFlags = z.infer<typeof featureFlagsSchema>;


### PR DESCRIPTION
## Summary
Sub-phase A5 of [scheduling v1 plan](../../scheduling/docs/scheduling_implementation_plan.md). Adds the scheduling block + feature_flags shape to `tenantConfigSchema` and implements all 6 cross-section invariants from `scheduling_config_schema.md` §10.

- `scheduling: schedulingConfigSchema.optional()` (top-level)
- `feature_flags: featureFlagsSchema.optional()` — passthrough so existing flags (`V4_ACTION_SELECTOR`, `DYNAMIC_CHIPS`, etc.) remain valid; only `scheduling_enabled` is typed
- 6 superRefine invariants in `tenantConfigSchema`:
  1. `scheduling_enabled === true` ⟹ scheduling block present
  2. `appointment_types[*].routing_policy_id` ∈ `routing_policies`
  3. `routing_policies[*].tag_conditions[*].tag` ∈ `scheduling_tag_vocabulary`
  4. `scheduling.pre_call_form_id`, when set, ∈ `conversational_forms`
  5. `scheduling.default_locale` ∈ `scheduling.available_locales`
  6. Scheduling CTAs require `scheduling_enabled === true` AND non-empty `appointment_types`

## Test plan
- [x] 11 new tests covering each invariant + baseline + passthrough — all passing locally
- [x] Full schema test suite green: 41/41 across `cta.schema`, `scheduling.schema`, `tenant.schema.scheduling`
- [x] `npm run typecheck` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)