### PR TITLE
fix(cta): add selection_metadata to ctaDefinitionSchema (CF1 from picasso PR #56)

### DIFF
--- a/docs/CTA_SELECTION_METADATA_TYPING.md
+++ b/docs/CTA_SELECTION_METADATA_TYPING.md
@@ -1,0 +1,27 @@
+# CF1 — Add `selection_metadata` to `ctaDefinitionSchema`
+
+**Tracker for follow-up PR escalated from PR #56 (config schema adversarial review).**
+
+## Background
+
+During the adversarial review of `scheduling/docs/scheduling_config_schema.md` (picasso PR #56), the typescript-specialist found that `selection_metadata` is documented in §9 of the schema spec and used by V4.1 pool selection (`topic_definitions` + CTA filtering by `selection_metadata.topic_tags` and `role_axis`), but the field is **not declared in `ctaDefinitionSchema`** in `picasso-config-builder/src/lib/schemas/cta.schema.ts`.
+
+The TypeScript type `CTADefinition` (in `src/types/config.ts:222`) declares `selection_metadata?: SelectionMetadata`, but the runtime Zod schema does not. Consequence: when a tenant config containing `selection_metadata` is parsed and then re-serialized through the config builder, the field is silently dropped.
+
+This is a pre-existing V4.1 data-loss risk on config builder round-trips — not introduced by any recent change. Escalated as a separate PR per "do not conflate review fixes with code fixes" guidance from PR #56.
+
+## Acceptance criteria
+
+- `selection_metadata` is declared as an optional field on `ctaDefinitionSchema` matching the `SelectionMetadata` TypeScript shape in `src/types/config.ts:213-225`.
+- The Zod definition uses `.passthrough()` semantics OR an explicit object schema — whichever matches existing patterns in the file. Pick the strictest reasonable form.
+- `z.infer<typeof ctaDefinitionSchema>` agrees with the existing `CTADefinition` interface (no diff after the change).
+- New unit test in `src/lib/schemas/__tests__/cta.schema.test.ts`: round-trip a CTA definition that includes `selection_metadata.topic_tags` and `selection_metadata.role_axis`, confirm the parsed result preserves the field.
+- Existing CTA tests still pass.
+- `npm run validate` passes.
+- `verify-before-commit` skill marker present before commit.
+
+## Out of scope
+
+- Don't refactor adjacent CTA schema code.
+- Don't extend `selection_metadata` schema beyond what's already in `SelectionMetadata` in `config.ts`.
+- Don't touch `tenant.schema.ts` invariants — this is a CTA-shape fix only.

--- a/src/lib/schemas/__tests__/cta.schema.test.ts
+++ b/src/lib/schemas/__tests__/cta.schema.test.ts
@@ -79,6 +79,41 @@ describe('ctaDefinitionSchema — scheduling actions (A4)', () => {
   });
 });
 
+describe('ctaDefinitionSchema — selection_metadata (CF1)', () => {
+  it('round-trips a CTA with selection_metadata.topic_tags and role_axis populated', () => {
+    const input = {
+      label: 'Learn about volunteering',
+      action: 'show_info',
+      type: 'info_request',
+      prompt: 'Tell me about volunteering opportunities',
+      ai_available: true,
+      selection_metadata: {
+        topic_tags: ['volunteer', 'get_involved'],
+        depth_level: 'info' as const,
+        role_axis: 'give' as const,
+        core_learning: true,
+        priority: 30,
+      },
+    };
+    const parsed = ctaDefinitionSchema.parse(input);
+    expect(parsed.selection_metadata?.topic_tags).toEqual(['volunteer', 'get_involved']);
+    expect(parsed.selection_metadata?.role_axis).toBe('give');
+    expect(parsed.selection_metadata?.depth_level).toBe('info');
+    expect(parsed.selection_metadata?.core_learning).toBe(true);
+    expect(parsed.selection_metadata?.priority).toBe(30);
+  });
+
+  it('accepts a CTA without selection_metadata (field is optional)', () => {
+    const parsed = ctaDefinitionSchema.parse({
+      label: 'Apply Now',
+      action: 'start_form',
+      type: 'form_trigger',
+      formId: 'volunteer_apply',
+    });
+    expect(parsed.selection_metadata).toBeUndefined();
+  });
+});
+
 describe('ctaDefinitionSchema — pre-existing actions remain valid', () => {
   it('still accepts start_form + form_trigger with formId', () => {
     expect(() =>

--- a/src/lib/schemas/cta.schema.ts
+++ b/src/lib/schemas/cta.schema.ts
@@ -43,6 +43,16 @@ export const ctaDefinitionSchema = z.object({
     .boolean()
     .optional()
     .describe('When true, includes this CTA in the AI vocabulary for dynamic selection (Tier 1-2 scoring).'),
+  selection_metadata: z
+    .object({
+      topic_tags: z.array(z.string()),
+      depth_level: z.enum(['info', 'action', 'lateral']),
+      role_axis: z.enum(['give', 'receive', 'learn', 'connect']).optional(),
+      core_learning: z.boolean().optional(),
+      priority: z.number().optional(),
+    })
+    .optional()
+    .describe('V4.1 Pool Selection metadata. Controls how this CTA is filtered and ranked by selectCTAsFromPool().'),
 }).superRefine((data, ctx) => {
   // Validate action-specific required fields (v1.3+)
 


### PR DESCRIPTION
## Summary

Escalated from picasso PR [#56](https://github.com/longhornrumble/picasso/pull/56) (config schema adversarial review).

`selection_metadata` is documented in scheduling_config_schema.md §9 and used by V4.1 pool selection, but the field is **not declared in the runtime Zod schema** (`ctaDefinitionSchema` in `src/lib/schemas/cta.schema.ts`). The TypeScript `CTADefinition` interface declares it; the Zod schema doesn't.

**Consequence:** when a tenant config containing `selection_metadata` is parsed and re-serialized through the config builder, the field is silently dropped. Pre-existing V4.1 data-loss risk on round-trips.

## Tracker doc

`docs/CTA_SELECTION_METADATA_TYPING.md` (this PR) — full background, acceptance criteria, out-of-scope guidance.

## Test plan

- [ ] `selection_metadata` declared on `ctaDefinitionSchema` matching the `SelectionMetadata` shape in `src/types/config.ts:213-225`
- [ ] `z.infer<typeof ctaDefinitionSchema>` agrees with existing `CTADefinition` interface
- [ ] New unit test: round-trip a CTA with `selection_metadata.topic_tags` + `role_axis`, verify field preserved
- [ ] Existing CTA tests still pass
- [ ] `npm run validate` clean
- [ ] `verify-before-commit` skill marker present before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)