### PR TITLE
feat(scheduling): config-builder UI wiring + i18n scaffolding (A7, A8b)

### DIFF
--- a/docs/CODE_REVIEW_CHECKLIST.md
+++ b/docs/CODE_REVIEW_CHECKLIST.md
@@ -1,0 +1,57 @@
+# Code Review Checklist
+
+**Purpose.** Mandatory checklist for any PR that touches scheduling-related code. Reviewers run through this list and cite it by file path in review comments when an item is not satisfied. Required by implementation plan A8b as the enforcement mechanism for multi-language scaffolding conventions.
+
+---
+
+## Scheduling-Touched Files
+
+The following paths define "scheduling-touched" for this checklist. Any PR that adds or modifies files under these paths must pass all mandatory items below.
+
+- `scheduling/`
+- `Picasso/src/components/scheduling/`
+- `customer-portal/src/components/scheduling/`
+- `picasso-config-builder/src/components/scheduling/`
+- `Lambdas/lambda/Bedrock_Streaming_Handler_Staging/scheduling/`
+- `Lambdas/lambda/Scheduling_*/` (any Lambda starting with `Scheduling_`)
+
+---
+
+## Mandatory: Scheduling-Touched Files
+
+These three items are required for every PR touching the paths above. A PR may not merge with any of these outstanding.
+
+- [ ] **All user-facing strings go through `t(key)` indirection.** No raw string literals in scheduling-touched files. v1 populates English keys only; the indirection layer is the point. Grep check: `grep -rn '"[A-Z]'` in scheduling-touched JS/TS files should return no results in user-facing string positions.
+
+- [ ] **No hand-formatted dates or times.** Use `Intl.DateTimeFormat` (JS/TS) or `babel.dates` (Python) for all date/time rendering. Grep check: `grep -rn 'toLocaleString\|\.getHours\|\.getMinutes\|strftime'` in scheduling-touched files should return no results outside of formatting utility modules.
+
+- [ ] **No `margin-left` or `margin-right` in scheduling-touched stylesheets.** Use CSS logical properties: `margin-inline-start` and `margin-inline-end`. Grep check: `grep -rn 'margin-left\|margin-right'` in scheduling-touched CSS/SCSS files should return no results.
+
+---
+
+## General: All PRs
+
+Brief carry-over from existing review practice. Apply to every PR, not just scheduling-touched ones.
+
+- [ ] Tests added alongside new code — no new logic without a corresponding test.
+- [ ] No commented-out code in committed files.
+- [ ] Comments explain the *why*, not the *what* — code already says what; comments explain intent, constraints, and non-obvious decisions.
+- [ ] No premature abstractions — no factory/registry/plugin pattern for code that has one current caller.
+
+---
+
+## How to Use
+
+During PR review: work through the relevant sections top to bottom. For any item not satisfied, leave an inline comment on the offending line citing this file:
+
+> Per `picasso-config-builder/docs/CODE_REVIEW_CHECKLIST.md` — this string literal must go through `t(key)` indirection.
+
+PRs may not be approved with open mandatory items. General items that cannot be addressed immediately should have a tracking ticket reference before merge.
+
+---
+
+## Change log
+
+| Date | Change | Author |
+|---|---|---|
+| 2026-05-02 | Initial — authored for sub-phase A8b multi-language scaffolding enforcement | Chris + Claude |

--- a/src/components/editors/CTAsEditor/CTAFormFields.tsx
+++ b/src/components/editors/CTAsEditor/CTAFormFields.tsx
@@ -32,6 +32,8 @@ export const CTAFormFields: React.FC<FormFieldsProps<CTAEntity>> = ({
     { value: 'external_link', label: 'External Link' },
     { value: 'send_query', label: 'Send Query' },
     { value: 'show_info', label: 'Show Info' },
+    { value: 'start_scheduling', label: 'Start Scheduling' },
+    { value: 'resume_scheduling', label: 'Resume Scheduling' },
   ];
 
   const typeOptions = [
@@ -39,6 +41,7 @@ export const CTAFormFields: React.FC<FormFieldsProps<CTAEntity>> = ({
     { value: 'external_link', label: 'External Link' },
     { value: 'bedrock_query', label: 'Bedrock Query' },
     { value: 'info_request', label: 'Info Request' },
+    { value: 'scheduling_trigger', label: 'Scheduling Trigger' },
   ];
 
   const formOptions = forms.map((f) => ({
@@ -101,6 +104,8 @@ export const CTAFormFields: React.FC<FormFieldsProps<CTAEntity>> = ({
               external_link: 'external_link',
               send_query: 'bedrock_query',
               show_info: 'info_request',
+              start_scheduling: 'scheduling_trigger',
+              resume_scheduling: 'scheduling_trigger',
             };
 
             // Update action, type, and clear conditional fields

--- a/src/components/editors/CTAsEditor/__tests__/CTAFormFields.scheduling.test.tsx
+++ b/src/components/editors/CTAsEditor/__tests__/CTAFormFields.scheduling.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * CTAFormFields — scheduling action wiring (sub-phase A7).
+ *
+ * A7 adds start_scheduling / resume_scheduling to the Action dropdown and
+ * maps them to the scheduling_trigger type. Scheduling actions are
+ * metadata-driven (the scheduling config lives in the tenant `scheduling`
+ * block, not on the CTA) so — unlike start_form/external_link/send_query/
+ * show_info — they render NO conditional input field. These tests assert
+ * that conditional-render contract. The action→type contract itself is
+ * compile-checked by the exhaustive Record<CTAActionType,CTAType> and
+ * covered end-to-end by cta.schema.test.ts / tenant.schema.scheduling.test.ts.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// useConfigStore selectors used by CTAFormFields: forms/branches/programs lists.
+vi.mock('@/store', () => ({
+  useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      forms: { getAllForms: () => [] },
+      branches: { getAllBranches: () => [] },
+      programs: { getAllPrograms: () => [] },
+    })
+  ),
+}));
+
+import { CTAFormFields } from '../CTAFormFields';
+import type { CTAEntity } from '../types';
+import type { CTAActionType, CTAType } from '@/types/config';
+
+function renderField(action: CTAActionType, type: CTAType) {
+  const value: CTAEntity = { ctaId: 'cta_1', label: 'Book a call', action, type };
+  return render(
+    <CTAFormFields
+      value={value}
+      onChange={vi.fn()}
+      errors={{}}
+      touched={{}}
+      onBlur={vi.fn()}
+      isEditMode={false}
+    />
+  );
+}
+
+// Anchors that uniquely identify each non-scheduling action's conditional field.
+const URL_PLACEHOLDER = 'https://example.com';
+const QUERY_PLACEHOLDER = /Enter the query to send to Bedrock/;
+const MESSAGE_PLACEHOLDER = /Enter information to display/;
+
+describe('CTAFormFields — scheduling actions render no conditional field', () => {
+  it.each([
+    ['start_scheduling'],
+    ['resume_scheduling'],
+  ] as const)('%s: no Form/URL/Query/Message conditional input', (action) => {
+    renderField(action, 'scheduling_trigger');
+
+    // Core selects always present.
+    expect(screen.getByText('Action')).toBeInTheDocument();
+    expect(screen.getByText('Type')).toBeInTheDocument();
+
+    // None of the other actions' conditional fields appear.
+    expect(screen.queryByText('Form')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(URL_PLACEHOLDER)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(QUERY_PLACEHOLDER)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(MESSAGE_PLACEHOLDER)).not.toBeInTheDocument();
+  });
+
+  it('contrast — start_form DOES render its Form conditional field', () => {
+    // Proves the absence assertions above are meaningful, not vacuous.
+    renderField('start_form', 'form_trigger');
+    expect(screen.getByText('Form')).toBeInTheDocument();
+  });
+
+  it('contrast — external_link DOES render its URL conditional field', () => {
+    renderField('external_link', 'external_link');
+    expect(screen.getByPlaceholderText(URL_PLACEHOLDER)).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/FeatureFlagsSettings.tsx
+++ b/src/components/settings/FeatureFlagsSettings.tsx
@@ -25,6 +25,11 @@ const FLAG_DEFINITIONS: FlagDefinition[] = [
     label: 'V4.0 Action Selector',
     description: 'LLM-based CTA selection — AI picks 0-4 relevant CTAs per turn from ai_available vocabulary',
   },
+  {
+    key: 'scheduling_enabled',
+    label: 'Scheduling',
+    description: 'Enables the v1 scheduling block — required for start_scheduling/resume_scheduling CTAs and the scheduling configuration section',
+  },
 ];
 
 // ============================================================================

--- a/src/components/settings/__tests__/FeatureFlagsSettings.scheduling.test.tsx
+++ b/src/components/settings/__tests__/FeatureFlagsSettings.scheduling.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * FeatureFlagsSettings — scheduling_enabled flag (sub-phase A7).
+ *
+ * A7 adds a `scheduling_enabled` entry to FLAG_DEFINITIONS so operators can
+ * toggle the v1 scheduling block from the Pipeline Feature Flags panel.
+ * These tests assert the new flag renders, reflects config state, and that
+ * toggling it writes feature_flags.scheduling_enabled through the store.
+ * The plain <input type="checkbox"> (no Radix) keeps these non-brittle.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+let mockBaseConfig: Record<string, unknown> = {};
+const mockSetState = vi.fn();
+
+vi.mock('@/store', () => ({
+  useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ config: { baseConfig: mockBaseConfig, isDirty: false } })
+  ),
+}));
+
+import { useConfigStore } from '@/store';
+import { FeatureFlagsSettings } from '../FeatureFlagsSettings';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBaseConfig = {};
+  (useConfigStore as unknown as { setState: typeof mockSetState }).setState = mockSetState;
+});
+
+describe('FeatureFlagsSettings — scheduling_enabled flag', () => {
+  it('renders the Scheduling flag with its description', () => {
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByText('Scheduling')).toBeInTheDocument();
+    expect(
+      screen.getByText(/required for start_scheduling\/resume_scheduling CTAs/)
+    ).toBeInTheDocument();
+  });
+
+  it('does not regress the existing V4.0 Action Selector flag', () => {
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByText('V4.0 Action Selector')).toBeInTheDocument();
+  });
+
+  it('checkbox is unchecked when feature_flags is absent', () => {
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByLabelText('Scheduling')).not.toBeChecked();
+  });
+
+  it('checkbox is checked when feature_flags.scheduling_enabled is true', () => {
+    mockBaseConfig = { feature_flags: { scheduling_enabled: true } };
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByLabelText('Scheduling')).toBeChecked();
+  });
+
+  it('toggling on writes feature_flags.scheduling_enabled = true through the store', async () => {
+    const user = userEvent.setup();
+    render(<FeatureFlagsSettings />);
+
+    await user.click(screen.getByLabelText('Scheduling'));
+
+    expect(mockSetState).toHaveBeenCalledTimes(1);
+
+    // Run the captured Immer-style updater against a draft to assert its effect.
+    const updater = mockSetState.mock.calls[0][0] as (s: unknown) => void;
+    const draft = { config: { baseConfig: {} as Record<string, unknown>, isDirty: false } };
+    updater(draft);
+
+    expect(draft.config.baseConfig).toEqual({
+      feature_flags: { scheduling_enabled: true },
+    });
+    expect(draft.config.isDirty).toBe(true);
+  });
+});

--- a/src/lib/i18n/__tests__/i18n.test.ts
+++ b/src/lib/i18n/__tests__/i18n.test.ts
@@ -1,0 +1,63 @@
+/**
+ * i18n indirection — sub-phase A8b.
+ *
+ * Verify check (impl plan A8b): `t('test_key')` returns the English string
+ * for a known key. Also covers `{param}` interpolation and the
+ * non-crashing fallbacks (unknown key, missing param) plus the sanctioned
+ * Intl-based date formatter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { t, formatDateTime, type MessageKey } from '../index';
+
+describe('t() — message indirection', () => {
+  it('returns the English string for a known key', () => {
+    expect(t('scheduling.test_key')).toBe('Scheduling is configured.');
+  });
+
+  it('interpolates {param} placeholders', () => {
+    expect(t('scheduling.test_key_param', { name: 'Dana' })).toBe('Booked with Dana.');
+  });
+
+  it('coerces non-string params', () => {
+    expect(t('scheduling.test_key_param', { name: 7 })).toBe('Booked with 7.');
+  });
+
+  it('returns the template verbatim when no params are given', () => {
+    expect(t('scheduling.test_key_param')).toBe('Booked with {name}.');
+  });
+
+  it('leaves a placeholder intact when its param is missing (non-crashing)', () => {
+    expect(t('scheduling.test_key_param', {})).toBe('Booked with {name}.');
+  });
+
+  it('returns the key itself for an unknown key (non-crashing)', () => {
+    expect(t('scheduling.does_not_exist' as MessageKey)).toBe('scheduling.does_not_exist');
+  });
+
+  it("defaults locale to 'en' and accepts an explicit 'en'", () => {
+    expect(t('scheduling.test_key', undefined, 'en')).toBe('Scheduling is configured.');
+  });
+});
+
+describe('formatDateTime() — sanctioned Intl wrapper', () => {
+  const date = new Date('2026-05-18T14:30:00Z');
+
+  it('delegates to Intl.DateTimeFormat', () => {
+    const opts: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      timeZone: 'UTC',
+    };
+    expect(formatDateTime(date, opts)).toBe(
+      new Intl.DateTimeFormat('en', opts).format(date)
+    );
+  });
+
+  it('produces a stable string for a fixed UTC date', () => {
+    expect(
+      formatDateTime(date, { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'UTC' })
+    ).toBe('05/18/2026');
+  });
+});

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1,0 +1,15 @@
+/**
+ * English message catalog — the only locale populated for scheduling v1
+ * (impl plan sub-phase A8b: "v1 only populates `en` keys").
+ *
+ * Scheduling UI strings are added here as later sub-phases (C/D/E) build
+ * user-facing surfaces. Sub-phase A seeds the structure only; the two keys
+ * below exist to exercise the `t()` indirection and its `{param}`
+ * interpolation. Keys are dot-namespaced by surface.
+ */
+export const en = {
+  'scheduling.test_key': 'Scheduling is configured.',
+  'scheduling.test_key_param': 'Booked with {name}.',
+} as const;
+
+export type MessageKey = keyof typeof en;

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Minimal i18n indirection for scheduling — impl plan sub-phase A8b.
+ *
+ * Purpose: establish the `t(key, params)` indirection layer NOW so scheduling
+ * UI built in later sub-phases never hardcodes user-facing strings ("cheap
+ * now, expensive to retrofit later", canonical §15.1).
+ *
+ * Deliberately NOT a full i18n engine. Per A8b tightened scope (tech-lead
+ * review 2026-05-02), locale switching, the mock `xx` locale, and a custom
+ * ESLint/stylelint rule were all cut as gold-plating for an English-only v1.
+ * The convention (all user-facing scheduling strings via `t()`; dates via the
+ * `formatDateTime` helper below; CSS logical properties) is enforced by
+ * `picasso-config-builder/docs/CODE_REVIEW_CHECKLIST.md`, not by tooling.
+ *
+ * v1 ships English only. `locale` defaults to 'en' and is the single
+ * supported value today; the parameter exists so call sites are already
+ * locale-shaped when a non-English tenant lands — this mirrors the scheduling
+ * config's `default_locale` / `available_locales` (BCP-47, default 'en').
+ */
+import { en, type MessageKey } from './en';
+
+const CATALOGS = { en } as const;
+export type Locale = keyof typeof CATALOGS;
+export type { MessageKey };
+
+export type TParams = Record<string, string | number>;
+
+/**
+ * Resolve a catalog key to its string, interpolating `{name}` placeholders
+ * from `params`. An unknown key returns the key itself, and a placeholder
+ * with no matching param is left intact — both are visible-but-non-crashing
+ * so a gap surfaces in review/QA without breaking the rendered UI (same
+ * forward-compatible-read discipline as the schema readers).
+ */
+export function t(key: MessageKey, params?: TParams, locale: Locale = 'en'): string {
+  const catalog = CATALOGS[locale] ?? CATALOGS.en;
+  const template: string = catalog[key] ?? key;
+  if (!params) return template;
+  return template.replace(/\{(\w+)\}/g, (match, name: string) =>
+    name in params ? String(params[name]) : match
+  );
+}
+
+/**
+ * Sanctioned date/time rendering for scheduling. Wraps `Intl.DateTimeFormat`
+ * so no scheduling-touched file hand-formats dates (the checklist's
+ * date-format guard explicitly carves out "formatting utility modules" —
+ * this is that module). `locale` defaults to 'en' for v1.
+ */
+export function formatDateTime(
+  date: Date,
+  options?: Intl.DateTimeFormatOptions,
+  locale: Locale = 'en'
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(date);
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -174,8 +174,19 @@ export interface ConversationalForm {
 // CTAs (Call-to-Actions)
 // ============================================================================
 
-export type CTAActionType = 'start_form' | 'external_link' | 'send_query' | 'show_info';
-export type CTAType = 'form_trigger' | 'external_link' | 'bedrock_query' | 'info_request';
+export type CTAActionType =
+  | 'start_form'
+  | 'external_link'
+  | 'send_query'
+  | 'show_info'
+  | 'start_scheduling'
+  | 'resume_scheduling';
+export type CTAType =
+  | 'form_trigger'
+  | 'external_link'
+  | 'bedrock_query'
+  | 'info_request'
+  | 'scheduling_trigger';
 
 export interface CTADefinition {
   text?: string; // Legacy field, use label instead
@@ -542,6 +553,8 @@ export interface TopicDefinition {
 export interface FeatureFlags {
   /** V4.0 Action Selector — LLM-based CTA selection from ai_available vocabulary */
   V4_ACTION_SELECTOR?: boolean;
+  /** Enables the v1 scheduling block — gates scheduling CTAs and the scheduling config section */
+  scheduling_enabled?: boolean;
   /** Allow additional flags from existing configs */
   [key: string]: boolean | undefined;
 }


### PR DESCRIPTION
Scheduling v1 implementation plan — **sub-phase A, config-builder UI cluster** (`scheduling/docs/scheduling_implementation_plan.md` §3). Builds on the already-merged schema work A3/A4/A5 (#19/#22/#43).

## A7 — UI wiring
- `CTAFormFields`: `start_scheduling`/`resume_scheduling` added to the Action dropdown + `typeOptions` + the action→type map (`scheduling_trigger`).
- `FeatureFlagsSettings`: `scheduling_enabled` added to `FLAG_DEFINITIONS` (operator-toggleable v1 scheduling block).
- `types/config.ts`: extend `CTAActionType`/`CTAType` + add `FeatureFlags.scheduling_enabled`. **Closes an A4 type-drift gap** — A4/A5 extended the Zod schemas but left these hand-maintained TS unions stale; the exhaustive `Record<CTAActionType,CTAType>` won't compile without it.

## A8b — i18n scaffolding (tightened scope, English-only v1)
- `src/lib/i18n/`: `t(key, params)` indirection (en catalog) + `formatDateTime` Intl wrapper. No locale engine / mock-locale / custom lint rule (cut per tech-lead review 2026-05-02).
- `docs/CODE_REVIEW_CHECKLIST.md`: A8b enforcement deliverable (pre-authored 2026-05-02), committed as required by the A8b verify check.

## Verification
- `tsc --noEmit` ✅ · `eslint --max-warnings 0` ✅ · `build:production` ✅
- `vitest run`: **34 files, 493 passed, 0 failed** (18 new — CTAFormFields 4, FeatureFlagsSettings 5, i18n 9)
- **Waived (1):** `actionToTypeMap` value not UI-driven (Radix Select portal not reliably drivable in jsdom; no pointer shims). Triple-guarded by tsc exhaustiveness + tested `cta.schema` superRefine + tested `tenant.schema` Invariant-6-positive — a wrong value is rejected at config-validation by tested schema code.

## Scope / not in this PR
Sub-phase A remainder (A8, A8c, CI-1/2/3a/5/8) and the parent submodule-pointer bump are deliberately out of scope (separate work; pointer bump deferred until sub-phase A is solid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)