### PR TITLE
test(scheduling): mock-s3 schema snapshot guard + fixture modernization (CI-1)

### DIFF
--- a/mock-s3/TEST001-config.json
+++ b/mock-s3/TEST001-config.json
@@ -1,181 +1,31 @@
 {
   "tenant_id": "TEST001",
-  "version": "1.3",
-  "chat_title": "Test Company HR Assistant",
-  "company_name": "Test Company Inc.",
-  "last_updated": "2025-10-15T10:00:00.000Z",
-  "programs": {
-    "employee_referral": {
-      "program_id": "employee_referral",
-      "program_name": "Employee Referral Program",
-      "description": "Refer qualified candidates and earn rewards",
-      "eligibility": {
-        "employment_type": ["full-time", "part-time"],
-        "min_tenure_days": 90
-      },
-      "rewards": {
-        "amount": 2000,
-        "currency": "USD",
-        "payment_schedule": "Upon candidate's 90-day completion"
-      }
-    },
-    "tuition_reimbursement": {
-      "program_id": "tuition_reimbursement",
-      "program_name": "Tuition Reimbursement",
-      "description": "Get reimbursed for approved educational courses",
-      "eligibility": {
-        "employment_type": ["full-time"],
-        "min_tenure_days": 180
-      },
-      "coverage": {
-        "max_annual_amount": 5000,
-        "currency": "USD",
-        "approved_courses": ["job-related", "degree-program"]
-      }
-    }
-  },
-  "conversational_forms": {
-    "employee_referral_form": {
-      "form_id": "employee_referral_form",
-      "form_name": "Employee Referral Submission",
-      "description": "Submit a referral for our Employee Referral Program",
-      "fields": [
-        {
-          "field_id": "referrer_name",
-          "field_label": "Your Full Name",
-          "field_type": "text",
-          "required": true,
-          "validation": {
-            "min_length": 2,
-            "max_length": 100
-          }
-        },
-        {
-          "field_id": "referrer_email",
-          "field_label": "Your Email",
-          "field_type": "email",
-          "required": true
-        },
-        {
-          "field_id": "candidate_name",
-          "field_label": "Candidate's Full Name",
-          "field_type": "text",
-          "required": true,
-          "validation": {
-            "min_length": 2,
-            "max_length": 100
-          }
-        },
-        {
-          "field_id": "candidate_email",
-          "field_label": "Candidate's Email",
-          "field_type": "email",
-          "required": true
-        },
-        {
-          "field_id": "position",
-          "field_label": "Position Applying For",
-          "field_type": "text",
-          "required": true
-        },
-        {
-          "field_id": "relationship",
-          "field_label": "How do you know this candidate?",
-          "field_type": "textarea",
-          "required": true,
-          "validation": {
-            "min_length": 10,
-            "max_length": 500
-          }
-        }
-      ],
-      "submission": {
-        "endpoint": "https://api.example.com/referrals",
-        "method": "POST"
-      }
-    }
-  },
-  "cta_definitions": {
-    "apply_now": {
-      "cta_id": "apply_now",
-      "cta_text": "Apply Now",
-      "cta_type": "primary",
-      "action": {
-        "type": "url",
-        "target": "https://careers.testcompany.com/apply"
-      }
-    },
-    "learn_more": {
-      "cta_id": "learn_more",
-      "cta_text": "Learn More",
-      "cta_type": "secondary",
-      "action": {
-        "type": "url",
-        "target": "https://careers.testcompany.com"
-      }
-    },
-    "submit_referral": {
-      "cta_id": "submit_referral",
-      "cta_text": "Submit Referral",
-      "cta_type": "primary",
-      "action": {
-        "type": "form",
-        "form_id": "employee_referral_form"
-      }
-    }
-  },
-  "conversation_branches": {
-    "benefits_inquiry": {
-      "branch_id": "benefits_inquiry",
-      "branch_name": "Benefits Information",
-      "trigger": {
-        "keywords": ["benefits", "insurance", "health", "dental", "vision"]
-      },
-      "response": "We offer comprehensive benefits including health, dental, and vision insurance. Would you like to know more about a specific benefit?"
-    },
-    "referral_program": {
-      "branch_id": "referral_program",
-      "branch_name": "Referral Program Info",
-      "trigger": {
-        "keywords": ["referral", "refer", "employee referral"]
-      },
-      "response": "Our Employee Referral Program rewards you for referring qualified candidates. You can earn up to $2,000 per successful hire!",
-      "cta": "submit_referral"
-    }
-  },
+  "tenant_hash": "test001hash00000000000000000000",
+  "subscription_tier": "Standard",
+  "chat_title": "TEST001 HR Assistant",
+  "tone_prompt": "You are a helpful HR assistant for TEST001.",
+  "welcome_message": "Hello! How can I help you today?",
+  "version": "1.5",
+  "generated_at": 1700000000,
+  "conversational_forms": {},
+  "cta_definitions": {},
+  "conversation_branches": {},
   "branding": {
     "primary_color": "#0066CC",
-    "secondary_color": "#00AA66",
-    "logo_url": "https://example.com/logo.png",
     "font_family": "Inter, sans-serif"
   },
   "features": {
-    "streaming_enabled": true,
-    "forms_enabled": true,
-    "smart_cards_enabled": true
-  },
-  "quick_help": [
-    "Tell me about benefits",
-    "Submit a referral",
-    "Find open positions"
-  ],
-  "action_chips": [
-    {
-      "label": "Benefits",
-      "action": "Tell me about benefits"
-    },
-    {
-      "label": "Referrals",
-      "action": "How do I refer someone?"
-    }
-  ],
-  "widget_behavior": {
-    "greeting_message": "Hi! I'm your HR assistant. How can I help you today?",
-    "placeholder_text": "Ask me anything...",
-    "auto_open": false
+    "uploads": false,
+    "photo_uploads": false,
+    "voice_input": false,
+    "streaming": true,
+    "conversational_forms": false,
+    "smart_cards": false,
+    "callout": { "enabled": false, "auto_dismiss": false }
   },
   "aws": {
-    "bedrock_model_id": "anthropic.claude-3-5-haiku-20241022-v1:0",
-    "knowledge_base_id": "TEST_KB_001"
-  }
+    "knowledge_base_id": "KBABCDEFGH12",
+    "aws_region": "us-east-1"
+  },
+  "channels": {}
 }

--- a/mock-s3/TEST002-config.json
+++ b/mock-s3/TEST002-config.json
@@ -1,154 +1,31 @@
 {
   "tenant_id": "TEST002",
-  "version": "1.3",
+  "tenant_hash": "test002hash00000000000000000000",
+  "subscription_tier": "Premium",
   "chat_title": "Acme Corp Recruiting",
-  "company_name": "Acme Corporation",
-  "last_updated": "2025-10-14T15:30:00.000Z",
-  "programs": {
-    "signing_bonus": {
-      "program_id": "signing_bonus",
-      "program_name": "Signing Bonus",
-      "description": "Competitive signing bonuses for select positions",
-      "eligibility": {
-        "positions": ["Software Engineer", "Data Scientist", "Product Manager"],
-        "level": ["mid", "senior", "staff"]
-      },
-      "bonus": {
-        "amount_range": [5000, 20000],
-        "currency": "USD",
-        "payment_schedule": "30 days after start date"
-      }
-    },
-    "relocation_assistance": {
-      "program_id": "relocation_assistance",
-      "program_name": "Relocation Assistance",
-      "description": "Support for candidates relocating for work",
-      "eligibility": {
-        "min_distance_miles": 50,
-        "positions": ["all"]
-      },
-      "coverage": {
-        "max_amount": 10000,
-        "currency": "USD",
-        "covered_expenses": ["moving", "temporary_housing", "travel"]
-      }
-    }
-  },
-  "conversational_forms": {
-    "contact_recruiter": {
-      "form_id": "contact_recruiter",
-      "form_name": "Contact Recruiter",
-      "description": "Get in touch with our recruiting team",
-      "fields": [
-        {
-          "field_id": "full_name",
-          "field_label": "Full Name",
-          "field_type": "text",
-          "required": true
-        },
-        {
-          "field_id": "email",
-          "field_label": "Email Address",
-          "field_type": "email",
-          "required": true
-        },
-        {
-          "field_id": "phone",
-          "field_label": "Phone Number",
-          "field_type": "phone",
-          "required": false
-        },
-        {
-          "field_id": "interest",
-          "field_label": "What position are you interested in?",
-          "field_type": "text",
-          "required": true
-        },
-        {
-          "field_id": "message",
-          "field_label": "Additional Information",
-          "field_type": "textarea",
-          "required": false
-        }
-      ],
-      "submission": {
-        "endpoint": "https://api.acmecorp.com/recruiting/contact",
-        "method": "POST"
-      }
-    }
-  },
-  "cta_definitions": {
-    "view_jobs": {
-      "cta_id": "view_jobs",
-      "cta_text": "View Open Positions",
-      "cta_type": "primary",
-      "action": {
-        "type": "url",
-        "target": "https://careers.acmecorp.com/jobs"
-      }
-    },
-    "contact_us": {
-      "cta_id": "contact_us",
-      "cta_text": "Contact Recruiter",
-      "cta_type": "secondary",
-      "action": {
-        "type": "form",
-        "form_id": "contact_recruiter"
-      }
-    }
-  },
-  "conversation_branches": {
-    "job_search": {
-      "branch_id": "job_search",
-      "branch_name": "Job Search",
-      "trigger": {
-        "keywords": ["jobs", "openings", "positions", "careers", "hiring"]
-      },
-      "response": "We have several exciting positions available! What type of role are you looking for?",
-      "cta": "view_jobs"
-    },
-    "company_culture": {
-      "branch_id": "company_culture",
-      "branch_name": "Company Culture",
-      "trigger": {
-        "keywords": ["culture", "values", "work environment", "team"]
-      },
-      "response": "At Acme Corp, we value innovation, collaboration, and work-life balance. Our team is passionate about building great products while maintaining a supportive work environment."
-    }
-  },
+  "tone_prompt": "You are a friendly recruiting assistant for Acme Corporation.",
+  "welcome_message": "Welcome to Acme! Looking to join our team?",
+  "version": "1.5",
+  "generated_at": 1700000000,
+  "conversational_forms": {},
+  "cta_definitions": {},
+  "conversation_branches": {},
   "branding": {
-    "primary_color": "#FF6B35",
-    "secondary_color": "#004E89",
-    "logo_url": "https://acmecorp.com/logo.png",
-    "font_family": "Roboto, sans-serif"
+    "primary_color": "#AA0066",
+    "font_family": "Inter, sans-serif"
   },
   "features": {
-    "streaming_enabled": true,
-    "forms_enabled": true,
-    "smart_cards_enabled": true
-  },
-  "quick_help": [
-    "View open positions",
-    "Learn about culture",
-    "Contact recruiter"
-  ],
-  "action_chips": [
-    {
-      "label": "Jobs",
-      "action": "Show me open positions"
-    },
-    {
-      "label": "Culture",
-      "action": "Tell me about your culture"
-    }
-  ],
-  "widget_behavior": {
-    "greeting_message": "Welcome to Acme Corp! Looking for your next career opportunity?",
-    "placeholder_text": "Ask about jobs, culture, benefits...",
-    "auto_open": false
+    "uploads": false,
+    "photo_uploads": false,
+    "voice_input": false,
+    "streaming": true,
+    "conversational_forms": false,
+    "smart_cards": false,
+    "callout": { "enabled": false, "auto_dismiss": false }
   },
   "aws": {
-    "bedrock_model_id": "anthropic.claude-3-5-haiku-20241022-v1:0",
-    "knowledge_base_id": "ACME_KB_002"
-  }
+    "knowledge_base_id": "KBACMEKB0001",
+    "aws_region": "us-east-1"
+  },
+  "channels": {}
 }

--- a/src/lib/schemas/__tests__/mock-s3-snapshot.test.ts
+++ b/src/lib/schemas/__tests__/mock-s3-snapshot.test.ts
@@ -1,0 +1,39 @@
+/**
+ * CI-1 — mock-s3 schema snapshot (impl plan scheduling sub-phase A §3).
+ *
+ * Every fixture the local dev server serves from mock-s3/ must parse against
+ * the current tenantConfigSchema. Purpose: a schema change that breaks an
+ * existing mock config → red CI; a backward-compatible change → green. Runs
+ * on every PR via the existing `npm run test:run` step in pr-checks.yml (no
+ * workflow change needed).
+ *
+ * Note: TEST001/TEST002 were rewritten 2026-05-19 from deeply stale v1.3
+ * shapes (105 combined schema issues) to minimal current-schema-valid
+ * configs — they are local-dev scaffolding keyed by tenant ID, not real
+ * tenant data. CI-2 (separate) guards real production configs from S3.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tenantConfigSchema } from '../tenant.schema';
+
+const MOCK_S3 = join(process.cwd(), 'mock-s3');
+const fixtures = readdirSync(MOCK_S3).filter((f) => f.endsWith('-config.json'));
+
+describe('CI-1: mock-s3 fixtures parse against tenantConfigSchema', () => {
+  it('finds fixtures to guard (guards against an empty/mispathed glob)', () => {
+    expect(fixtures.length).toBeGreaterThan(0);
+  });
+
+  it.each(fixtures)('%s parses with no schema errors', (file) => {
+    const raw = JSON.parse(readFileSync(join(MOCK_S3, file), 'utf8'));
+    const result = tenantConfigSchema.safeParse(raw);
+    if (!result.success) {
+      const summary = result.error.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('\n  ');
+      throw new Error(`${file} failed tenantConfigSchema:\n  ${summary}`);
+    }
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Scheduling v1 sub-phase A, task **CI-1** — regression guard that every `mock-s3` fixture parses against the current `tenantConfigSchema`.

## Investigation finding (why this is more than "add a test")
`TEST001`/`TEST002` were deeply stale **v1.3-era** configs — **56 + 49 = 105** combined schema-conformance issues (invalid form field types, invalid CTA actions/types, `quick_help`/`action_chips` as arrays, wrong `features`/`aws` shapes, branches missing `available_ctas`). The local dev server has been serving schema-invalid mocks. Per the chosen approach, both were rewritten as **minimal current-schema-valid** configs (modeled on the proven A5 `baseTenant` shape). They are local-dev scaffolding keyed by tenant ID — consumers verified to use the **ID**, not deep fixture content; real production configs are guarded separately by CI-2.

## Changes
- `mock-s3/TEST001/TEST002-config.json` — minimal valid v1.5 configs.
- `src/lib/schemas/__tests__/mock-s3-snapshot.test.ts` — iterates `mock-s3/*-config.json`, `safeParse` each, readable `path: message` summary on failure; "finds fixtures" guard against an empty glob. Auto-runs via the existing `npm run test:run` (no workflow change).

## Verify
CI-1 3/3 · full suite **35 files / 496 passed** (+3, no regression — DraftBanner/client.draft/deploymentWorkflow reference TEST001/002 by ID, confirmed non-coupled) · `tsc` 0 · `eslint --max-warnings 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)