### PR TITLE
fix(schemas): widen form->program join to accept key OR .program_id

### DIFF
--- a/src/lib/schemas/__tests__/tenant.schema.forwardcompat.test.ts
+++ b/src/lib/schemas/__tests__/tenant.schema.forwardcompat.test.ts
@@ -157,3 +157,64 @@ describe('cta.schema forward-compat: query allowed on non-send_query CTAs', () =
     expect(r.success).toBe(true);
   });
 });
+
+describe('tenant.schema forward-compat: form->program join accepts key OR .program_id (matches FormCardContent.tsx:18)', () => {
+  // Real AUS123957 shape: programs object keyed by something other than the
+  // program_id field (e.g. key="love_box_application", program_id="love_box_request",
+  // and key="request_daretodream", program_id="daretodream_request"). Forms reference
+  // either form. Schema must match pcb's actual display lookup at
+  // FormCardContent.tsx:18 (key first, .program_id fallback).
+  const cfgWithFormRef = (formProgramRef: string) => ({
+    ...baseTenant(),
+    programs: {
+      love_box_application: {
+        program_id: 'love_box_request',
+        program_name: 'Love Box Application',
+      },
+      request_daretodream: {
+        program_id: 'daretodream_request',
+        program_name: 'Dare to Dream Request',
+      },
+    },
+    conversational_forms: {
+      love_box_referral: {
+        enabled: true,
+        form_id: 'love_box_referral',
+        program: formProgramRef,
+        title: 'Love Box Referral',
+        description: 'Refer a family for a Love Box.',
+        fields: [
+          {
+            id: 'family_name',
+            type: 'text' as const,
+            label: 'Family name',
+            prompt: 'What is the family name?',
+            required: true,
+          },
+        ],
+      },
+    },
+  });
+
+  it('accepts form.program matching a program.program_id (key !== program_id)', () => {
+    expect(tenantConfigSchema.safeParse(cfgWithFormRef('love_box_request')).success).toBe(true);
+  });
+
+  it('accepts form.program matching only the object key (real AUS dare2dream_referral shape)', () => {
+    expect(tenantConfigSchema.safeParse(cfgWithFormRef('request_daretodream')).success).toBe(true);
+  });
+
+  it('REJECTS form.program matching neither key nor any program_id', () => {
+    const r = tenantConfigSchema.safeParse(cfgWithFormRef('nonexistent_program'));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some(
+          (i) =>
+            i.path.join('.') === 'conversational_forms.love_box_referral.program' &&
+            i.code === 'custom',
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/src/lib/schemas/tenant.schema.ts
+++ b/src/lib/schemas/tenant.schema.ts
@@ -307,11 +307,21 @@ export const tenantConfigSchema = z.object({
     }
   }
 
-  // Validate that all form programs reference existing programs (if programs are defined)
+  // Validate that all form programs reference existing programs (if programs are defined).
+  // A form.program is valid if it matches EITHER the programs object key OR a
+  // program's .program_id field. This matches FormCardContent.tsx:18 (the canonical
+  // display lookup: `programs[entity.program] || Object.values(programs).find(p => p.program_id === entity.program)`),
+  // accommodates real prod data where key !== .program_id (verified on AUS123957
+  // 2026-05-23), and stays consistent with the runtime which treats refs as flat
+  // strings and doesn't enforce join semantics.
   if (data.programs) {
-    const programIds = new Set(Object.keys(data.programs));
+    const validProgramRefs = new Set<string>();
+    for (const [programKey, program] of Object.entries(data.programs)) {
+      validProgramRefs.add(programKey);
+      validProgramRefs.add(program.program_id);
+    }
     Object.entries(data.conversational_forms).forEach(([formId, form]) => {
-      if (!programIds.has(form.program)) {
+      if (!validProgramRefs.has(form.program)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['conversational_forms', formId, 'program'],


### PR DESCRIPTION
## Summary

The `superRefine` in `tenantConfigSchema` validates that every form's `program` field references an existing program. The original check used `Object.keys(data.programs)` only. **That's too strict relative to the canonical display lookup** at [`FormCardContent.tsx:18`](https://github.com/longhornrumble/picasso-config-builder/blob/main/src/components/editors/FormsEditor/FormCardContent.tsx#L18):

```ts
const program = programs[entity.program]
  || Object.values(programs).find((p) => p.program_id === entity.program);
```

This PR widens the schema check to match: `form.program` is valid if it matches **either** an object key **or** any program's `.program_id`. Variable renamed to `validProgramRefs` for clarity.

## Why

Real prod data verified on `AUS123957` 2026-05-23:

| Object key | .program_id |
|---|---|
| love_box_application | love_box_request |
| request_daretodream | daretodream_request |
| volunteer_daretodream | daretodream_volunteer |
| voluteer_lovebox | lovebox_volunteer |
| donate | donate |
| donate_items | donate_items |

5 of 6 forms reference `.program_id`. 1 form (`dare2dream_referral`) references the object key. pcb correctly displays "Program: Dare to Dream Request" for all 6 — both join styles are valid in the codebase as-shipped, and the runtime (`response_enhancer.js`) treats `cta.program` / `form.program` as flat strings without joining at all.

The schema was the only place rejecting valid data. Pre-fix, AUS123957 failed schema validation with 3 issues (the program_id-matching forms). Post-fix, it passes cleanly.

## What changed

- `src/lib/schemas/tenant.schema.ts` — superRefine builds `validProgramRefs` from both keys and `.program_id` values; form-ref check passes if `form.program` matches any. 4-line explanatory comment added.
- `src/lib/schemas/__tests__/tenant.schema.forwardcompat.test.ts` — 3 new regression tests following PR #47 pattern:
  - positive: form refs program by `.program_id` when key !== program_id → PASS
  - positive: form refs program by object key (real `dare2dream_referral` shape) → PASS
  - negative: form refs string matching neither → FAIL

## Risk

**No runtime behavior change.** Only the schema validation surface is affected (used by CI-2 prod-config gate, pcb pre-deployment validation, and `relationshipValidation.ts`). The widget continues to use flat-string equality and doesn't enforce join semantics.

`relationshipValidation.ts:92` still uses `.program_id`-only — separately inconsistent with `FormCardContent.tsx:18` but not changed here (out of scope for this surgical fix; can be widened in a follow-up if desired).

## Test plan

- [x] Full suite: `npm run test:run` — 508/508 PASS (was 505/505; +3 new)
- [x] Typecheck: `npm run typecheck` — clean
- [x] Lint: `npx eslint` on changed files — clean
- [x] Inline check against real `AUS123957-config.json` (downloaded from `s3://myrecruiter-picasso`) — 0 schema issues under widened check
- [ ] (Reviewer) Verify the 4-line comment in `tenant.schema.ts` correctly cites `FormCardContent.tsx:18`

## Context

Surfaced by the CI-2 prod-config-validation gate work (`feature/ci-2-prod-config-validation`, not yet open as a PR). Merging this PR first unblocks landing CI-2 cleanly — all 4 prod tenants (`ATL642715`, `AUS123957`, `FOS402334`, `MYR384719`) will pass the gate.

Mistake-correction history is in the session handoff memory (TL;DR: I made 2 wrong calls before this one — first claiming the data was wrong, then making the schema too strict on `.program_id`-only — operator caught both).