### PR TITLE
feat(ci): add CI-2 prod-config schema-validation gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -111,3 +111,60 @@ jobs:
           name: config-builder-build
           path: dist/
           retention-days: 7
+
+  prod-config-validation:
+    name: Prod Config Schema Validation
+    # CI-2 gate: validate all prod tenant configs against the live schema on
+    # any PR that touches src/lib/schemas/**. Catches forward-compat breakage
+    # before merge. Design + threat model: project_scheduling_subphase_a_ci2_phase0_design_2026-05-19.
+    #
+    # Trigger conditions (defense in depth — IAM trust also pins event_name):
+    #   - pull_request event only (not pull_request_target — silently bypasses fork-OIDC)
+    #   - skip fork PRs (head.repo.fork == false)
+    #   - skip dependabot/renovate bot PRs (cannot assume the OIDC role meaningfully)
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write     # required for OIDC token exchange
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Detect schema changes
+        id: schema-changed
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+        with:
+          filters: |
+            schemas:
+              - 'src/lib/schemas/**'
+
+      - name: Setup Node.js
+        if: steps.schema-changed.outputs.schemas == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.schema-changed.outputs.schemas == 'true'
+        run: npm ci
+
+      - name: Configure AWS credentials (prod-614 read-only)
+        if: steps.schema-changed.outputs.schemas == 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
+        with:
+          role-to-assume: ${{ secrets.PROD_CONFIG_CI_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: ci-config-pr-${{ github.event.pull_request.number }}
+
+      - name: Validate prod tenant configs against schema
+        if: steps.schema-changed.outputs.schemas == 'true'
+        run: npx tsx scripts/validate-prod-configs.ts
+        env:
+          S3_BUCKET: myrecruiter-picasso

--- a/scripts/validate-prod-configs.ts
+++ b/scripts/validate-prod-configs.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * CI-2: validate every prod tenant config against the live tenantConfigSchema.
+ *
+ * Runs in GitHub Actions on PRs that touch src/lib/schemas/**. Fetches each
+ * tenant config from s3://${S3_BUCKET}/tenants/{ID}/{ID}-config.json, parses
+ * it, and exits non-zero if any tenant fails schema validation.
+ *
+ * Security constraints (Rec-4 + threat-model T-09 considerations):
+ *   - log only { path, code } per Zod issue
+ *   - NEVER log error.format() / error.flatten() / issue.message — superRefine
+ *     at tenant.schema.ts:283 embeds program-ID strings into messages
+ *   - NEVER log raw config bytes (no JSON.parse error.message either — it
+ *     includes a context byte from the source on failure)
+ *   - NEVER store config as a CI artifact
+ *
+ * Design + apply checklist + threat model:
+ *   ~/.claude/projects/.../memory/project_scheduling_subphase_a_ci2_phase0_design_2026-05-19.md
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { tenantConfigSchema } from '../src/lib/schemas/tenant.schema';
+
+const execFileP = promisify(execFile);
+
+const S3_BUCKET = process.env.S3_BUCKET;
+if (!S3_BUCKET) {
+  process.stderr.write('FATAL: S3_BUCKET env var is required\n');
+  process.exit(2);
+}
+
+type ValidationResult =
+  | { tenantId: string; ok: true }
+  | { tenantId: string; ok: false; reason: 'fetch_failed'; awsCode: string | null }
+  | { tenantId: string; ok: false; reason: 'invalid_json' }
+  | { tenantId: string; ok: false; reason: 'schema_failed'; issues: Array<{ path: string; code: string }> };
+
+async function listTenantIds(bucket: string): Promise<string[]> {
+  const { stdout } = await execFileP('aws', [
+    's3api', 'list-objects-v2',
+    '--bucket', bucket,
+    '--prefix', 'tenants/',
+    '--delimiter', '/',
+    '--output', 'json',
+  ]);
+  const parsed = JSON.parse(stdout) as { CommonPrefixes?: Array<{ Prefix: string }> };
+  return (parsed.CommonPrefixes ?? [])
+    .map((p) => p.Prefix.replace(/^tenants\//, '').replace(/\/$/, ''))
+    .filter((id) => id.length > 0)
+    .sort();
+}
+
+async function fetchAndValidate(bucket: string, tenantId: string): Promise<ValidationResult> {
+  const key = `tenants/${tenantId}/${tenantId}-config.json`;
+
+  let stdout: string;
+  try {
+    const result = await execFileP(
+      'aws',
+      ['s3', 'cp', `s3://${bucket}/${key}`, '-'],
+      { maxBuffer: 16 * 1024 * 1024 }
+    );
+    stdout = result.stdout;
+  } catch (e) {
+    const stderr = (e as { stderr?: string }).stderr ?? '';
+    const match = stderr.match(/\(([A-Z][A-Za-z]+)\)/);
+    return { tenantId, ok: false, reason: 'fetch_failed', awsCode: match?.[1] ?? null };
+  }
+
+  let config: unknown;
+  try {
+    config = JSON.parse(stdout);
+  } catch {
+    return { tenantId, ok: false, reason: 'invalid_json' };
+  }
+
+  const result = tenantConfigSchema.safeParse(config);
+  if (result.success) {
+    return { tenantId, ok: true };
+  }
+  return {
+    tenantId,
+    ok: false,
+    reason: 'schema_failed',
+    issues: result.error.issues.map((i) => ({
+      path: i.path.join('.'),
+      code: i.code,
+    })),
+  };
+}
+
+async function main(): Promise<void> {
+  process.stdout.write(`CI-2: validating prod tenant configs in s3://${S3_BUCKET}/tenants/\n`);
+
+  const tenantIds = await listTenantIds(S3_BUCKET!);
+  process.stdout.write(`Found ${tenantIds.length} tenant(s): ${tenantIds.join(', ')}\n`);
+  if (tenantIds.length === 0) {
+    process.stderr.write(`FATAL: no tenants found in s3://${S3_BUCKET}/tenants/\n`);
+    process.exit(2);
+  }
+
+  const results = await Promise.all(tenantIds.map((id) => fetchAndValidate(S3_BUCKET!, id)));
+
+  let failures = 0;
+  for (const r of results) {
+    if (r.ok) {
+      process.stdout.write(`  PASS  ${r.tenantId}\n`);
+      continue;
+    }
+    failures++;
+    if (r.reason === 'fetch_failed') {
+      process.stdout.write(`  FAIL  ${r.tenantId}  reason=fetch_failed  awsCode=${r.awsCode ?? '<none>'}\n`);
+    } else if (r.reason === 'invalid_json') {
+      process.stdout.write(`  FAIL  ${r.tenantId}  reason=invalid_json\n`);
+    } else {
+      process.stdout.write(`  FAIL  ${r.tenantId}  reason=schema_failed  issues=${r.issues.length}\n`);
+      for (const issue of r.issues) {
+        process.stdout.write(`        path=${issue.path}  code=${issue.code}\n`);
+      }
+    }
+  }
+
+  process.stdout.write('\n');
+  if (failures > 0) {
+    process.stderr.write(`FAIL: ${failures}/${results.length} tenant(s) failed schema validation\n`);
+    process.exit(1);
+  }
+  process.stdout.write(`PASS: all ${results.length} tenant(s) validated against current schema\n`);
+}
+
+main().catch((err: unknown) => {
+  const name = (err as Error)?.name ?? 'UnknownError';
+  const code = (err as { code?: string | number })?.code;
+  const codeStr = code !== undefined ? ` (code=${String(code)})` : '';
+  process.stderr.write(`FATAL: ${name}${codeStr}\n`);
+  process.exit(2);
+});


### PR DESCRIPTION
> ## ⚠️ DO NOT MERGE UNTIL THE PROD-614 IAM APPLY HAS COMPLETED
>
> Merging this PR before the apply session lands the IAM role + GH secret will hard-fail every future `src/lib/schemas/**` PR with an OIDC auth error. The apply session opens the role + secret in a single atomic operator window per the design checklist.
>
> The new `prod-config-validation` job in this PR's own diff correctly **skips** (no `src/lib/schemas/**` changes here), so this PR will not fail in CI today. The risk is only at merge time.

## Summary

Adds the CI-2 gate from scheduling sub-phase A acceptance — any PR touching `src/lib/schemas/**` fetches all prod tenant configs via OIDC (read-only IAM role on prod-614) and validates each against the live `tenantConfigSchema`. Catches forward-compat breakage before merge.

Two files:
- **`scripts/validate-prod-configs.ts`** (NEW, 137 LoC, tsx-runnable) — lists tenants under `s3://myrecruiter-picasso/tenants/`, fetches each `{ID}/{ID}-config.json`, runs `tenantConfigSchema.safeParse`, exits non-zero if any tenant fails. Per security spec (Rec-4), output is limited to `{ path, code }` per Zod issue — never `.message`, `.format()`, `.flatten()`, JSON.parse messages, or raw config bytes.
- **`.github/workflows/pr-checks.yml`** (modified, +57 lines) — new `prod-config-validation` job. Gated on schema changes via `dorny/paths-filter`. Fork PRs + bot PRs excluded. All 4 actions SHA-pinned. Dynamic `role-session-name = ci-config-pr-{pr.number}` for CloudTrail correlation.

## Design + threat model + apply checklist

Authoritative design (gate-approved 2026-05-19): memory `project_scheduling_subphase_a_ci2_phase0_design_2026-05-19.md`

Adversarial review by Security-Reviewer (APPROVED-WITH-MITIGATIONS). All blocking findings folded in:
- **R-1 (BLOCKING T-02)**: IAM trust pins `event_name=pull_request` in addition to `sub` claim — closes the `pull_request_target` silent-bypass (same `sub` string). This is on the IAM trust policy itself, applied at the IAM step of the apply checklist.
- **R-2 (BLOCKING T-06)**: `prod-config-validation` MUST be added to required status checks on `main` at apply time (atomic with IAM role + secret). Without it, force-push-after-pass bypasses the gate.
- **Rec-1 (T-08)**: dynamic role-session-name → already in this PR.
- **Rec-2 (T-17)**: all 4 actions SHA-pinned → already in this PR.
- **Rec-3 (T-05)**: dependabot/renovate excluded in `if:` → already in this PR.
- **Rec-4**: script logs only `{ path, code }` → enforced by script implementation.
- **Rec-5 (4j/T-09)**: deferred to T-09 track (pre-existing public-read bucket; independent of CI-2).
- **Rec-6**: ADR-documented invariant — tenant configs must remain PII-free. Cross-link this to any PII Path A work that touches tenant configs.

## Apply checklist (operator session — separate, gated)

Per the design memory (do NOT merge this PR until all steps complete):
1. Pre-checks: confirm role still NoSuchEntity, OIDC provider present, branch protection state
2. `aws iam create-role --role-name picasso-config-ci-readonly` (prod-614, trust policy in design memory)
3. `aws iam put-role-policy` with `PicassoConfigReadOnly` (least-priv: `s3:ListBucket` on bucket + `s3:GetObject` on `tenants/*`)
4. `gh secret set PROD_CONFIG_CI_ROLE_ARN`
5. Merge this PR
6. Add `Prod Config Schema Validation` to required status checks on `main` (R-2 atomic with the merge)
7. Open a whitespace-only test PR in `src/lib/schemas/**` to exercise the gate end-to-end
8. Open a no-schema-change test PR to verify SKIP behavior

## Implementation deviation from design memory (justified)

Design memory specified `node scripts/validate-prod-configs.mjs`. This PR uses `npx tsx scripts/validate-prod-configs.ts` instead:
- `tsx` is already a dev dep (used by `server:dev`)
- Single-source schema import (no build step)
- Algorithm + Rec-4 output constraint unchanged

## Dependency

Depends on **PR #48** (widens the `form→program` join check in tenant.schema.ts to match `FormCardContent.tsx:18`). Without #48, AUS123957 fails schema validation under this gate. With #48 merged, all 4 remaining prod tenants pass cleanly.

Recommended merge order: #48 first, then this PR after IAM apply.

## Test plan

- [x] Smoke test 1: missing `S3_BUCKET` → FATAL + exit 2
- [x] Smoke test 2: real bucket end-to-end (5 tenants → 4 after NAT001622 deletion → 3 pass + 1 fail (AUS, pre-#48); 3 PASS, 1 fail correctly classified, no message/raw content leaked)
- [x] Post-#48 smoke: AUS123957 passes cleanly under widened schema → all 4 tenants PASS
- [ ] (Apply session) Exercise the gate end-to-end via test PR (apply checklist step 7)
- [ ] (Apply session) Verify SKIP behavior via no-schema test PR (step 8)
- [ ] (Apply session) Manually inspect job logs to confirm no config bytes leaked (Rec-4)

## Related

- **T-09 (myrecruiter-picasso public-read)**: Independent finding surfaced during this CI-2 design work. NOT introduced by this PR. Tracked at `docs/roadmap/MYR_PICASSO_BUCKET_PUBLIC_READ.md`.
- **NAT001622 deletion**: Operator-authorized 2026-05-23; the previously-failing 5th tenant was a stale 0-form/0-CTA scaffold. Removed from the prod bucket; backup at `Sandbox/NAT001622-deleted-2026-05-23/`.