### PR TITLE
fix(ci-2): relocate R-1/T-02 mitigation from IAM trust to workflow lint

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -118,8 +118,8 @@ jobs:
     # any PR that touches src/lib/schemas/**. Catches forward-compat breakage
     # before merge. Design + threat model: project_scheduling_subphase_a_ci2_phase0_design_2026-05-19.
     #
-    # Trigger conditions (defense in depth — IAM trust also pins event_name):
-    #   - pull_request event only (not pull_request_target — silently bypasses fork-OIDC)
+    # Trigger conditions (T-02 mitigation lives in workflow-trigger-guard job below):
+    #   - pull_request event only (the PR-target event variant is blocked at PR time by the trigger-guard)
     #   - skip fork PRs (head.repo.fork == false)
     #   - skip dependabot/renovate bot PRs (cannot assume the OIDC role meaningfully)
     if: |
@@ -168,3 +168,49 @@ jobs:
         run: npx tsx scripts/validate-prod-configs.ts
         env:
           S3_BUCKET: myrecruiter-picasso
+
+  workflow-trigger-guard:
+    name: Workflow Trigger Safety (T-02 mitigation)
+    # CI-2 design R-1 / T-02 mitigation — relocated 2026-05-24 from IAM trust
+    # to this lint job after empirically discovering that AWS STS does NOT
+    # expose `event_name` as an IAM condition key (the original R-1 fold-in
+    # produced AccessDenied on PR #51 step-12 verification — see CloudTrail
+    # event 6ba91f74-ed8b-4ecf-ba85-f3a8fc286031).
+    #
+    # GitHub's OIDC `sub` claim is identical for `pull_request` and the
+    # PR-target event variant. Since the IAM trust can only filter by sub+aud,
+    # introducing a PR-target trigger anywhere in this repo's workflows would
+    # let a fork PR assume picasso-config-ci-readonly in base-repo context
+    # with write permissions = privilege escalation.
+    #
+    # This job fails any PR that introduces such a trigger.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Forbid PR-target trigger in any workflow file
+        run: |
+          set -u
+          # Build the search literal at runtime so this script does not contain
+          # the literal token itself (would otherwise trip the guard when it
+          # scans pr-checks.yml).
+          pat="pull_request""_target"
+          hits=""
+          shopt -s nullglob
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            # Strip YAML comment tails (everything after #) before searching so
+            # that this file's own explanatory comments don't trip the guard.
+            if sed -E 's/#.*$//' "$f" | grep -qF "$pat"; then
+              hits="${hits}${f}\n"
+            fi
+          done
+          if [ -n "$hits" ]; then
+            echo "::error::T-02 trigger detected in workflow file(s):"
+            printf "%b" "$hits"
+            echo ""
+            echo "This is BLOCKED by CI-2 design's T-02 mitigation. See pr-checks.yml workflow-trigger-guard job header for full rationale."
+            exit 1
+          fi
+          echo "OK: no T-02 trigger found in any workflow file."


### PR DESCRIPTION
## Summary

CI-2's R-1 mitigation (block the PR-target event variant from silently assuming `picasso-config-ci-readonly` via the same `sub` claim) was originally implemented as an IAM trust-policy condition: pin `event_name=pull_request`.

**Empirically broken on 2026-05-24 PR #51 step-12 verification**: AWS STS returned `AccessDenied` on every OIDC assume-role attempt (11 retries before fail). CloudTrail event `6ba91f74-ed8b-4ecf-ba85-f3a8fc286031` confirms `sub` matched the trust condition but the assume-role still failed — strongly indicating **AWS STS does not expose `event_name` as an IAM condition key** (only `sub` + `aud` are standard).

This PR relocates the mitigation to the workflow layer + drops the broken IAM condition (out-of-band IAM `update-assume-role-policy` happening alongside this PR).

## What changed

- New job `workflow-trigger-guard` (`Workflow Trigger Safety (T-02 mitigation)`) in `pr-checks.yml`. Fails any PR that introduces a PR-target trigger anywhere in `.github/workflows/*.yml`.
- Reworded the existing `prod-config-validation` job comment so it no longer contains the literal token (would otherwise trip the new guard).
- Bash in the new guard uses a split-string pattern so the guard's own code doesn't contain the literal contiguously.

## Self-test (local, bash)

- ✅ Guard does not trip on any current pcb workflow file (including this updated `pr-checks.yml`)
- ✅ Positive control: synthetic `on:\n  pull_request_target:` correctly trips
- ✅ Negative control: literal-in-YAML-comment correctly skipped (sed strips `#.*$` before grep)

## R-1 protection intent preserved

If anyone tries to add a PR-target trigger to any workflow via a PR, this job fails the PR before it can land on main. Once added to required status checks on main, this is enforced at merge time — same intent as the original IAM-trust pin, just at a different layer.

## Follow-ups (operator owns)

- [ ] Add `Workflow Trigger Safety (T-02 mitigation)` to required status checks on `main`
- [ ] Update CI-2 design memory to record R-1 evolution