### PR TITLE
fix(ci-2): restore zero-tenant guard in runProdConfigsValidation (re-audit RE-B4)

### DIFF
--- a/scripts/validate-prod-configs.ts
+++ b/scripts/validate-prod-configs.ts
@@ -18,6 +18,7 @@ import {
   runProdConfigsValidation,
   parseTenantIdsFromCommonPrefixes,
   S3FetchError,
+  NoTenantsFoundError,
   type S3Reader,
 } from '../src/lib/validation/prodConfigsValidator';
 
@@ -63,11 +64,6 @@ async function main(): Promise<void> {
     log: (line) => process.stdout.write(line + '\n'),
   });
 
-  if (outcome.results.length === 0) {
-    process.stderr.write(`FATAL: no tenants found in s3://${bucket}/tenants/\n`);
-    process.exit(2);
-  }
-
   process.stdout.write('\n');
   if (outcome.failures > 0) {
     process.stderr.write(
@@ -81,6 +77,10 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: unknown) => {
+  if (err instanceof NoTenantsFoundError) {
+    process.stderr.write(`FATAL: ${err.message}\n`);
+    process.exit(2);
+  }
   const name = (err as Error)?.name ?? 'UnknownError';
   const code = (err as { code?: string | number })?.code;
   const codeStr = code !== undefined ? ` (code=${String(code)})` : '';

--- a/src/lib/validation/__tests__/prodConfigsValidator.test.ts
+++ b/src/lib/validation/__tests__/prodConfigsValidator.test.ts
@@ -15,6 +15,7 @@ import {
   parseTenantIdsFromCommonPrefixes,
   runProdConfigsValidation,
   S3FetchError,
+  NoTenantsFoundError,
   type S3Reader,
 } from '../prodConfigsValidator';
 
@@ -181,6 +182,28 @@ describe('runProdConfigsValidation', () => {
       // a leaked message string.
       expect(line).toMatch(/^\s*path=[^\s]*\s+code=[^\s]+\s*$/);
     }
+  });
+
+  it('throws NoTenantsFoundError when listTenantIds returns an empty array (audit RE-B4)', async () => {
+    // Re-audit RE-B4 regression: pre-refactor the CLI shell guarded against
+    // empty buckets at top-level. The extraction moved that guard into the
+    // CLI shell only, leaving any non-CLI caller to silently false-PASS on
+    // `failures: 0`. The guard now lives in runProdConfigsValidation so it
+    // travels with the function. This test pins that behavior.
+    const s3: S3Reader = {
+      async listTenantIds() {
+        return [];
+      },
+      async fetchObjectBody() {
+        throw new Error('should not be called');
+      },
+    };
+    await expect(
+      runProdConfigsValidation({ bucket: 'empty-bucket', s3, log: () => {} }),
+    ).rejects.toBeInstanceOf(NoTenantsFoundError);
+    await expect(
+      runProdConfigsValidation({ bucket: 'empty-bucket', s3, log: () => {} }),
+    ).rejects.toMatchObject({ bucket: 'empty-bucket' });
   });
 
   it('returns failures=0 when every tenant passes', async () => {

--- a/src/lib/validation/prodConfigsValidator.ts
+++ b/src/lib/validation/prodConfigsValidator.ts
@@ -42,6 +42,21 @@ export class S3FetchError extends Error {
 }
 
 /**
+ * Thrown when listTenantIds returns an empty array. Audit re-audit RE-B4:
+ * empty-bucket case must NOT silently return `failures: 0` from
+ * runProdConfigsValidation — that would be a false-PASS for any caller that
+ * doesn't separately inspect results.length.
+ */
+export class NoTenantsFoundError extends Error {
+  bucket: string;
+  constructor(bucket: string) {
+    super(`No tenants found in s3://${bucket}/tenants/`);
+    this.name = 'NoTenantsFoundError';
+    this.bucket = bucket;
+  }
+}
+
+/**
  * Parses the CommonPrefixes payload that `aws s3api list-objects-v2 --prefix
  * tenants/ --delimiter /` returns. Pulled out for direct unit-testing.
  */
@@ -111,6 +126,14 @@ export async function runProdConfigsValidation(
 
   const tenantIds = await opts.s3.listTenantIds(opts.bucket);
   log(`Found ${tenantIds.length} tenant(s): ${tenantIds.join(', ')}`);
+
+  // Audit re-audit RE-B4: empty bucket is a hard error, not a silent
+  // success. Pre-refactor the CLI shell had this guard at top-level; the
+  // extraction moved it out of the module which let any non-CLI caller
+  // false-PASS. Throw here so the guard travels with the function.
+  if (tenantIds.length === 0) {
+    throw new NoTenantsFoundError(opts.bucket);
+  }
 
   const results = await Promise.all(
     tenantIds.map((id) => fetchAndValidate(opts.s3, opts.bucket, id)),


### PR DESCRIPTION
## Summary

Closes re-audit blocker **RE-B4** (code-reviewer Finding 8) surfaced by the 2026-05-24 PM phase-completion-audit on the audit-triage work.

The B9 refactor (PR #54) moved the zero-tenant FATAL guard from the CLI shell's top-level check into nowhere — `runProdConfigsValidation` would happily return `{ failures: 0, results: [] }` on an empty bucket, silently false-PASSing for any non-CLI caller. The CLI shell still had the check so production behavior was preserved, but the module's contract was broken.

## Fix

- Add `NoTenantsFoundError` exported from `prodConfigsValidator.ts`
- Throw it from `runProdConfigsValidation` when `listTenantIds` returns `[]`
- CLI shell catches it explicitly and exits 2 with the original message
- Regression test pins the throw + the typed error's `bucket` field

The throw approach (vs. an outcome flag) forces all callers to handle the empty case rather than relying on a downstream `.length` check. The guard now travels with the function.

## Test plan

- [x] `npx vitest run prodConfigsValidator.test.ts` → 13/13 pass (was 12; +1 regression)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] verify-before-commit marker written

🤖 Generated with [Claude Code](https://claude.com/claude-code)