### PR TITLE
ci(deploy): deploy-production dispatch-only — end the stuck approval queue

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,6 +1,10 @@
 name: Deploy Picasso Config Builder
 
 on:
+  # Push to main runs the quality gates + build only. The deploy-production
+  # job is dispatch-only, so prod deploys are deliberate acts and merges never
+  # queue waiting-approval runs (CI-modernization Phase 0.3 — the queue had
+  # 8 runs stuck since 2026-05-24).
   push:
     branches:
       - main
@@ -123,6 +127,8 @@ jobs:
   deploy-production:
     name: Deploy to Production
     needs: [lint, typecheck, test, security, build]
+    # Dispatch-only (see `on:` comment): pushes stop after the build job.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: production
     permissions:


### PR DESCRIPTION
## What

Adds `if: github.event_name == 'workflow_dispatch'` to `deploy-production`. Push to main still runs lint/typecheck/test/security/build; the prod deploy fires only on manual dispatch.

## Why

Every merge queued a prod run at the `production` environment gate that nobody approved — **8 runs stranded since 2026-05-24** (drained 2026-06-09). Meanwhile prod (`picasso-config-builder-prod` S3, objects dated 2026-05-19) is **~3 weeks behind main**, missing among others the js-cookie CVE fix (#50) and the MYR384719 schema forward-compat fix (#47). A follow-up dispatch from current main will bring prod current once this merges.

Part of CI-modernization Phase 0.3 — `ci_modernization/docs/MODERNIZATION_PLAN.md` (in the platform repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)