### PR TITLE
ci(audit): concurrency guard + SHA-pin the reusable (picasso Phase-2 audit D1/D8)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,6 +23,13 @@ env:
   S3_BUCKET_PRODUCTION: 'picasso-config-builder-prod'
   CLOUDFRONT_DISTRIBUTION_ID: 'E3OTEE0UFN347Y'
 
+# Serialize runs (picasso Phase-2 audit D1): two simultaneous dispatches
+# would race the live-bucket sync (--delete) and the prev-release lookup
+# in the reusable. Queue behind a mid-flight run, never cancel it.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   lint:
     name: Code Quality - Linting
@@ -147,7 +154,11 @@ jobs:
       contents: read
     # Shared deploy mechanics (sync → invalidate → smoke) + the immutable
     # releases/<sha>/ rollback copy — CI-modernization Phase 2.1/2.2.
-    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@main
+    # SHA-pinned (picasso Phase-2 audit D8): @main meant any reusable change
+    # could startup_failure this workflow with no warning in THIS repo (the
+    # picasso#494 class). Bump deliberately to adopt reusable changes.
+    # Current pin = picasso#520 (audit hardening).
+    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@643e0d83cb9d625554652533e2be6176c202761d
     with:
       environment: production
       artifact_name: config-builder-build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -124,7 +124,9 @@ jobs:
     # mechanics live in the reusable workflow; serves the production-mode
     # bundle (UI preview — pcb has one build target). No CloudFront: plain
     # S3 website endpoint, so no invalidation needed.
-    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@main
+    # SHA-pinned (picasso Phase-2 audit D8) — keep in sync with the pin in
+    # deploy-production.yml; bump both deliberately to adopt reusable changes.
+    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@643e0d83cb9d625554652533e2be6176c202761d
     with:
       environment: staging
       artifact_name: config-builder-build


### PR DESCRIPTION
Picasso Phase-2 completion-audit findings **D1** (no concurrency guard — racing prod dispatches corrupt the live S3 sync) and **D8** (reusable pinned `@main` = silent startup_failure exposure, the picasso#494 class).

- `deploy-production.yml`: `concurrency: deploy-production` (queue, never cancel) + reusable pinned to `picasso@643e0d8` (#520 — smoke retries, archive cache-control, env-indirection)
- `pr-checks.yml`: same SHA pin on the staging-preview leg (kept in sync)

Adopting future reusable changes = deliberate pin bump in this repo. Twin of analytics-dashboard#25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)