### PR TITLE
fix(branches): tolerate old-shape branch records (BranchCardContent crash)

### DIFF
--- a/src/store/__tests__/branchNormalization.test.ts
+++ b/src/store/__tests__/branchNormalization.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Schema-discipline contract test: the store boundary must tolerate old-shape
+ * branch records (missing `secondary`, missing `available_ctas`) — the reader
+ * crash this pins: BranchCardContent reading `available_ctas.secondary.length`
+ * on a hand-seeded branch with only a `primary` CTA (MYR384719, 2026-06-12).
+ */
+import { describe, it, expect } from 'vitest';
+import { normalizeBranches } from '../slices/config';
+import type { ConversationBranch } from '@/types/config';
+
+describe('normalizeBranches (old-shape config records)', () => {
+  it('defaults a missing secondary array', () => {
+    const raw = {
+      schedule_call: {
+        available_ctas: { primary: 'schedule_intro_call' },
+        description: 'Schedule an intro call with the team',
+      },
+    } as unknown as Record<string, ConversationBranch>;
+
+    const out = normalizeBranches(raw);
+    expect(out.schedule_call.available_ctas.secondary).toEqual([]);
+    expect(out.schedule_call.available_ctas.primary).toBe('schedule_intro_call');
+    expect(out.schedule_call.description).toBe('Schedule an intro call with the team');
+  });
+
+  it('defaults a missing available_ctas object entirely', () => {
+    const raw = {
+      bare: { description: 'no ctas at all' },
+    } as unknown as Record<string, ConversationBranch>;
+
+    const out = normalizeBranches(raw);
+    expect(out.bare.available_ctas.primary).toBe('');
+    expect(out.bare.available_ctas.secondary).toEqual([]);
+  });
+
+  it('passes well-formed branches through unchanged', () => {
+    const raw: Record<string, ConversationBranch> = {
+      request_support: {
+        available_ctas: { primary: 'request_dare2dream', secondary: ['love_box_referral'] },
+        description: 'Request support',
+        program_id: 'daretodream_request',
+      } as ConversationBranch,
+    };
+
+    const out = normalizeBranches(raw);
+    expect(out.request_support).toEqual(raw.request_support);
+  });
+
+  it('tolerates undefined and null input', () => {
+    expect(normalizeBranches(undefined)).toEqual({});
+    expect(normalizeBranches(null)).toEqual({});
+  });
+
+  it('tolerates a null branch entry value', () => {
+    const raw = { broken: null } as unknown as Record<string, ConversationBranch>;
+    const out = normalizeBranches(raw);
+    expect(out.broken.available_ctas).toEqual({ primary: '', secondary: [] });
+  });
+});

--- a/src/store/slices/config.ts
+++ b/src/store/slices/config.ts
@@ -3,11 +3,35 @@
  * Manages configuration lifecycle: load, save, deploy, and merge operations
  */
 
-import type { TenantConfig, ConversationalForm } from '@/types/config';
+import type { TenantConfig, ConversationalForm, ConversationBranch } from '@/types/config';
 import type { SliceCreator, ConfigSlice } from '../types';
 import * as configAPI from '@/lib/api/config-operations';
 import { configApiClient } from '@/lib/api/client';
 import { ConfigAPIError } from '@/lib/api/errors';
+
+/**
+ * Schema discipline: stored configs may carry old-shape branches (no `secondary`
+ * array — hand-authored or pre-builder records). Readers across the app assume
+ * the canonical {primary, secondary[]} shape, so normalize once at the store
+ * boundary instead of guarding every consumer.
+ */
+export function normalizeBranches(
+  branches: Record<string, ConversationBranch> | undefined | null
+): Record<string, ConversationBranch> {
+  return Object.fromEntries(
+    Object.entries(branches || {}).map(([key, branch]) => [
+      key,
+      {
+        ...branch,
+        available_ctas: {
+          ...branch?.available_ctas,
+          primary: branch?.available_ctas?.primary ?? '',
+          secondary: branch?.available_ctas?.secondary ?? [],
+        },
+      },
+    ])
+  );
+}
 
 export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
   // State
@@ -58,7 +82,7 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         );
 
         state.ctas.ctas = response.config.cta_definitions || {};
-        state.branches.branches = response.config.conversation_branches || {};
+        state.branches.branches = normalizeBranches(response.config.conversation_branches);
         state.contentShowcase.content_showcase = response.config.content_showcase || [];
 
         // Clear any active selections
@@ -303,7 +327,7 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         );
 
         state.ctas.ctas = state.config.baseConfig.cta_definitions || {};
-        state.branches.branches = state.config.baseConfig.conversation_branches || {};
+        state.branches.branches = normalizeBranches(state.config.baseConfig.conversation_branches);
         state.contentShowcase.content_showcase = state.config.baseConfig.content_showcase || [];
 
         state.config.isDirty = false;
@@ -446,7 +470,7 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         );
 
         state.ctas.ctas = draftConfig.cta_definitions || {};
-        state.branches.branches = draftConfig.conversation_branches || {};
+        state.branches.branches = normalizeBranches(draftConfig.conversation_branches);
         state.contentShowcase.content_showcase = draftConfig.content_showcase || [];
 
         // Clear active selections


### PR DESCRIPTION
## Problem
Opening the **Branches** tab for MYR384719 crashed to the ErrorBoundary:
`TypeError: Cannot read properties of undefined (reading 'length')` at `BranchCardContent` (main.js prod bundle).

Root cause: `BranchCardContent.tsx:25` reads `branch.available_ctas.secondary.length` unguarded, and the tenant's `schedule_call` branch (hand-seeded 2026-06-12 for the scheduling pilot) legitimately carries only a `primary` CTA. `BranchFormFields` has the same exposure the moment the branch is edited. This violates the repo schema-discipline rule: readers must tolerate missing optional fields.

## Fix
One normalizer at the store boundary instead of optional-chains in every consumer: `normalizeBranches()` applied at the three sites that populate `state.branches.branches` (loadConfig, reset-to-base, draft load) — mirrors the existing `form_id` normalization precedent in the same file. All downstream readers (cards, form fields, dashboard, validation, slice ops) now see the canonical `{primary, secondary[]}` shape.

## Verification (verify-before-commit run)
- `branchNormalization.test.ts`: **5/5** (missing secondary / missing available_ctas / null entry / null+undefined maps / well-formed passthrough)
- Full suite: **530 passed, 0 failed** · `typecheck` clean · `lint` clean (max-warnings 0) · `build:production` exit 0 · `npm audit --omit=dev --audit-level=high` exit 0
- Post-deploy confirm: load MYR384719 → Branches tab renders the schedule_call card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)