### PR TITLE
ci: bump reusable pin to picasso@aec1b46e (D10 rollback fix)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -157,8 +157,10 @@ jobs:
     # SHA-pinned (picasso Phase-2 audit D8): @main meant any reusable change
     # could startup_failure this workflow with no warning in THIS repo (the
     # picasso#494 class). Bump deliberately to adopt reusable changes.
-    # Current pin = picasso#520 (audit hardening).
-    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@643e0d83cb9d625554652533e2be6176c202761d
+    # Current pin = picasso#561/#562 (D10 fix: the prior pin 643e0d8 carried
+    # an auto-rollback that would WIPE the live bucket; this pin rewrites it
+    # download-then-upload + adds an empty-source abort guard).
+    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@aec1b46e8d242b3d123a8b7ff51c41fc44e635e6
     with:
       environment: production
       artifact_name: config-builder-build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -126,7 +126,7 @@ jobs:
     # S3 website endpoint, so no invalidation needed.
     # SHA-pinned (picasso Phase-2 audit D8) — keep in sync with the pin in
     # deploy-production.yml; bump both deliberately to adopt reusable changes.
-    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@643e0d83cb9d625554652533e2be6176c202761d
+    uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@aec1b46e8d242b3d123a8b7ff51c41fc44e635e6
     with:
       environment: staging
       artifact_name: config-builder-build


### PR DESCRIPTION
Bumps both reusable references off `643e0d8` → `aec1b46e`.

The prior pin carried picasso#511's auto-rollback, which — dryrun-confirmed against the real bucket during the 2026-06-12 D10 incident — would **wipe the live bucket** on a failed prod smoke. picasso#561/#562 rewrote it download-then-upload + empty-source abort guard. Pure pin advance; no other behavior change. Twin of analytics-dashboard#32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)