### PR TITLE
ci(prod): prod-staleness-check + deploy tag (parity with widget)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -169,3 +169,27 @@ jobs:
       website_url: https://config.myrecruiter.ai
     secrets:
       deploy_role_arn: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+
+  # The reusable deploy job archives releases/<sha>/ but does NOT tag. This job
+  # supplies the deploy-production-* tag that prod-staleness-check.yml diffs
+  # against — without it the staleness check no-ops forever (no tags to compare).
+  # Mirrors the widget's post-deploy "Create deployment tag" step.
+  post-deploy:
+    name: Tag production deployment
+    needs: deploy-production
+    # Only when the prod deploy actually ran + succeeded (the deploy job is
+    # dispatch-gated behind approve-production; on a plain push it's skipped).
+    if: needs.deploy-production.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # pushes the deploy-production-* tag
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Create deployment tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          TAG_NAME="deploy-production-$(date +%Y%m%d-%H%M%S)"
+          git tag -a "$TAG_NAME" -m "Production deployment $TAG_NAME"
+          git push origin "$TAG_NAME"

--- a/.github/workflows/prod-staleness-check.yml
+++ b/.github/workflows/prod-staleness-check.yml
@@ -1,0 +1,89 @@
+name: Prod Staleness Check
+
+# Production deploys are dispatch-only (deploy-production.yml), so nothing
+# queues to signal "prod is behind". This check replaces that signal: weekly,
+# diff deployable paths since the last deploy-production-* tag and open an
+# issue if anything is pending. Parity with the widget's prod-staleness-check
+# (longhornrumble/picasso). The tag is pushed by deploy-production.yml's
+# post-deploy job on every successful prod deploy (this repo deploys via the
+# shared reusable, which does not tag — the post-deploy job supplies it).
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'   # Mondays 14:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Compare prod deploy tag to main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Diff deployable paths since last prod deploy
+        id: diff
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git tag -l 'deploy-production-*' --sort=-creatordate | head -1)
+          if [ -z "$LAST_TAG" ]; then
+            echo "No deploy-production-* tags found — nothing to compare." >> $GITHUB_STEP_SUMMARY
+            echo "stale=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "Last prod deploy tag: $LAST_TAG" >> $GITHUB_STEP_SUMMARY
+          # Deployable source only: exclude docs and CI workflows (neither ships
+          # in the built artifact).
+          PENDING=$(git log --oneline "$LAST_TAG"..main -- . ':!**/*.md' ':!.github/**' || true)
+          if [ -z "$PENDING" ]; then
+            echo "Prod is current — no deployable changes since $LAST_TAG." >> $GITHUB_STEP_SUMMARY
+            echo "stale=false" >> $GITHUB_OUTPUT
+          else
+            echo "stale=true" >> $GITHUB_OUTPUT
+            echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
+            {
+              echo 'pending<<PENDING_EOF'
+              echo "$PENDING"
+              echo 'PENDING_EOF'
+            } >> $GITHUB_OUTPUT
+            echo "Undeployed changes since $LAST_TAG:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$PENDING" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Open issue if stale (dedupe on open issue with same title)
+        if: steps.diff.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: 'Config Builder prod is behind main — undeployed changes'
+          PENDING: ${{ steps.diff.outputs.pending }}
+          LAST_TAG: ${{ steps.diff.outputs.last_tag }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Open staleness issue already exists — not duplicating." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          BODY=/tmp/staleness-issue-body.md
+          {
+            echo "Weekly prod-staleness check: deployable commits exist on \`main\` that are not in production (last deploy tag \`$LAST_TAG\`)."
+            echo ""
+            echo '```'
+            echo "$PENDING"
+            echo '```'
+            echo ""
+            echo "If these should ship: run the **Deploy Picasso Config Builder** workflow (dispatch) and approve the gate. If prod is intentionally held back, close this issue — the check re-opens it next week only while undeployed changes remain."
+            echo ""
+            echo "_Automated by \`.github/workflows/prod-staleness-check.yml\`._"
+          } > "$BODY"
+          gh issue create --title "$TITLE" --body-file "$BODY"


### PR DESCRIPTION
## What

Front-end staleness-detection **parity** with the widget. Production deploys here are dispatch-only, so `main` can silently drift ahead of what's live with nothing to signal it. The widget already has `prod-staleness-check.yml`; config-builder did not.

Two additions:

1. **`prod-staleness-check.yml`** (new) — weekly cron (Mon 14:00 UTC) + dispatch. Finds the newest `deploy-production-*` tag, diffs deployable paths since it (`-- . ':!**/*.md' ':!.github/**'`), and opens a **deduped** GitHub issue if anything is pending. Mirrors the widget's mechanism and warning channel exactly. **No AWS/OIDC** — git-native.

2. **`deploy-production.yml` → `post-deploy` job** — pushes a `deploy-production-*` tag on every **successful** prod deploy (`if: needs.deploy-production.result == 'success'`). 

## Why the tag job is required (not optional)

The widget's staleness check is **tag-based**. But the widget tags via its *hand-rolled* `deploy-production.yml`; config-builder deploys through the **shared reusable** `deploy-frontend.yml`, which archives `releases/<sha>/` but does **not** tag. So config-builder had **zero** `deploy-production-*` tags — a verbatim copy of the check would hit "no tags found → not stale" and **no-op forever**. The `post-deploy` job supplies the tag the check compares against.

> Alternative considered & rejected: an S3 `releases/<sha>/`-based check. That needs an OIDC role assumable from a cron run (the same prerequisite as the not-yet-built drift detection), i.e. an operator IAM change. The tag approach is git-native, needs no new IAM, and is exact parity with the widget.

## Verification

- Both files parse (`python yaml.safe_load`); `deploy-production.yml` jobs now end with `post-deploy`.
- `post-deploy` is gated `if: needs.deploy-production.result == 'success'`, so it never fires on a plain push (deploy is dispatch-gated behind `approve-production`) or a skipped/failed deploy.
- First real proof is post-merge: the next prod dispatch should create a `deploy-production-*` tag, after which the weekly check has a baseline.

Base `main` per CI-workflow branch routing.