### PR TITLE
feat(forms): 'book an appointment after this form' + post-booking question

### DIFF
--- a/src/components/editors/FormsEditor/PostSubmissionConfig.tsx
+++ b/src/components/editors/FormsEditor/PostSubmissionConfig.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState } from 'react';
 import { Input, Textarea, Button, Badge, Select } from '@/components/ui';
-import { Plus, X, Trash2, Webhook } from 'lucide-react';
+import { Plus, X, Trash2, Webhook, CalendarClock } from 'lucide-react';
 import type { PostSubmissionConfig as PostSubmissionConfigType, PostSubmissionAction, Fulfillment } from '@/types/config';
 
 export interface PostSubmissionConfigProps {
@@ -267,6 +267,65 @@ export const PostSubmissionConfig: React.FC<PostSubmissionConfigProps> = ({
         <p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
           Buttons shown after form submission (max 3)
         </p>
+      </div>
+
+      {/* Book an Appointment (scheduling pivot) */}
+      <div className="w-full border-t pt-4">
+        <div className="flex items-center justify-between mb-4">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={!!config.book_appointment}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  handleChange({ book_appointment: true });
+                } else {
+                  // Uncheck clears the coupled question so the runtime won't ask it.
+                  handleChange({ book_appointment: false, post_booking_question: undefined });
+                }
+              }}
+              className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+            />
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Book an appointment after this form
+            </span>
+          </label>
+        </div>
+
+        {config.book_appointment && (
+          <div className="space-y-4 pl-6 border-l-2 border-primary-200 dark:border-primary-800">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              After the form is submitted, the visitor is offered available times to book a call
+              (requires scheduling enabled for the tenant).
+            </p>
+            <div className="w-full">
+              <label
+                htmlFor="post-booking-question"
+                className="mb-1.5 flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                <CalendarClock className="w-4 h-4" />
+                Question to ask after booking
+              </label>
+              <Textarea
+                id="post-booking-question"
+                value={config.post_booking_question || ''}
+                onChange={(e) => handleChange({ post_booking_question: e.target.value })}
+                onBlur={onBlur}
+                placeholder="One last thing to help us prepare — what would you like to talk about?"
+                rows={2}
+              />
+              {touched && errors?.post_booking_question && (
+                <p className="mt-1.5 text-sm text-red-600 dark:text-red-400" role="alert">
+                  {errors.post_booking_question}
+                </p>
+              )}
+              <p className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                Optional. Asked in chat right after the booking is confirmed; the visitor's answer
+                is attached to the booking so the coordinator knows what they want to discuss.
+              </p>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Fulfillment Settings */}

--- a/src/components/editors/FormsEditor/__tests__/PostSubmissionConfig.test.tsx
+++ b/src/components/editors/FormsEditor/__tests__/PostSubmissionConfig.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * PostSubmissionConfig — "Book an appointment after this form" + post-booking question.
+ * The scheduling pivot the operator authors; drives the runtime form -> schedule -> ask chain.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PostSubmissionConfig } from '../PostSubmissionConfig';
+
+const base = { confirmation_message: 'Thanks — we received your application.' };
+
+describe('PostSubmissionConfig — book appointment + post-booking question', () => {
+  it('hides the question field until "Book an appointment" is enabled', () => {
+    render(<PostSubmissionConfig value={base} onChange={vi.fn()} />);
+    expect(screen.queryByLabelText(/question to ask after booking/i)).toBeNull();
+  });
+
+  it('checking "Book an appointment after this form" sets book_appointment: true', () => {
+    const onChange = vi.fn();
+    render(<PostSubmissionConfig value={base} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText(/book an appointment after this form/i));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ book_appointment: true }));
+  });
+
+  it('shows the question field when enabled and writes post_booking_question on input', () => {
+    const onChange = vi.fn();
+    render(<PostSubmissionConfig value={{ ...base, book_appointment: true }} onChange={onChange} />);
+    const textarea = screen.getByLabelText(/question to ask after booking/i);
+    fireEvent.change(textarea, { target: { value: 'What would you like to talk about?' } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ post_booking_question: 'What would you like to talk about?' }),
+    );
+  });
+
+  it('unchecking clears the coupled question (book_appointment:false + question undefined)', () => {
+    const onChange = vi.fn();
+    render(
+      <PostSubmissionConfig
+        value={{ ...base, book_appointment: true, post_booking_question: 'Q' }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/book an appointment after this form/i));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ book_appointment: false, post_booking_question: undefined }),
+    );
+  });
+});

--- a/src/lib/schemas/__tests__/form.schema.test.ts
+++ b/src/lib/schemas/__tests__/form.schema.test.ts
@@ -1,0 +1,39 @@
+/**
+ * form.schema.ts tests — postSubmissionConfigSchema scheduling pivot fields.
+ *
+ * The "book an appointment after this form" + post-booking question that drive the
+ * runtime form -> schedule -> ask chain (lambda §B post-booking amendment).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { postSubmissionConfigSchema } from '../form.schema';
+
+const base = { confirmation_message: 'Thanks — we received your application.' };
+
+describe('postSubmissionConfigSchema — book_appointment + post_booking_question', () => {
+  it('accepts book_appointment with a post-booking question', () => {
+    expect(() =>
+      postSubmissionConfigSchema.parse({
+        ...base,
+        book_appointment: true,
+        post_booking_question: 'What would you like to talk about?',
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts book_appointment without a question (question is optional)', () => {
+    expect(() => postSubmissionConfigSchema.parse({ ...base, book_appointment: true })).not.toThrow();
+  });
+
+  it('both fields are optional — a config with only the confirmation message parses', () => {
+    const parsed = postSubmissionConfigSchema.parse(base);
+    expect(parsed.book_appointment).toBeUndefined();
+    expect(parsed.post_booking_question).toBeUndefined();
+  });
+
+  it('rejects a post-booking question longer than 500 characters', () => {
+    expect(() =>
+      postSubmissionConfigSchema.parse({ ...base, post_booking_question: 'a'.repeat(501) }),
+    ).toThrow(/500 characters/);
+  });
+});

--- a/src/lib/schemas/form.schema.ts
+++ b/src/lib/schemas/form.schema.ts
@@ -173,6 +173,13 @@ export const postSubmissionConfigSchema = z.object({
   next_steps: z.array(z.string().max(500, 'Each next step must be 500 characters or less')).optional(),
   actions: z.array(postSubmissionActionSchema).max(3, 'Maximum 3 post-submission actions allowed').optional(),
   fulfillment: fulfillmentSchema.optional(),
+  // Scheduling pivot: offer to book an appointment after this form, and optionally ask one
+  // free-text question after the booking confirms (lands on the booking for the coordinator).
+  book_appointment: z.boolean().optional(),
+  post_booking_question: z
+    .string()
+    .max(500, 'Question must be 500 characters or less')
+    .optional(),
 });
 
 // ============================================================================

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -121,6 +121,17 @@ export interface PostSubmissionConfig {
   next_steps?: string[];
   actions?: PostSubmissionAction[];
   fulfillment?: Fulfillment;
+  /**
+   * When true, after this form is submitted the visitor is offered to book an appointment
+   * (requires scheduling enabled for the tenant). The "next step" pivot from form -> scheduling.
+   */
+  book_appointment?: boolean;
+  /**
+   * Optional free-text question asked AFTER the booking confirms ("what would you like to talk
+   * about?"). The answer lands on the booking so the coordinator knows what the visitor wants
+   * to discuss. Streamed as ordinary chat text; the visitor types their answer. Empty -> not asked.
+   */
+  post_booking_question?: string;
 }
 
 export interface FormNotificationConfig {


### PR DESCRIPTION
## What

Adds the operator-authored config for the **form → schedule → ask** chain: in a form's **Post-Submission Configuration**, a new **"Book an appointment after this form"** toggle that reveals an optional **"Question to ask after booking"** field.

This is the config surface (Segment 1) for the lambda feature shipped in [lambda#351](https://github.com/longhornrumble/lambda/pull/351). With both landed, an operator can configure: form submitted → offer to book → after booking, ask "what would you like to talk about?" → the answer reaches the coordinator on the booking.

## Changes
- **`PostSubmissionConfig.tsx`** — a checkbox (`book_appointment`) that, when on, reveals a `post_booking_question` textarea. Unchecking clears the coupled question (so the runtime won't ask it). Mirrors the existing Fulfillment section pattern.
- **`types/config.ts`** + **`form.schema.ts`** — two **optional** fields on `PostSubmissionConfig` (`book_appointment?: boolean`, `post_booking_question?: string`, capped 500 chars).

## Runtime alignment
The lambda reads `conversational_forms[form_id].post_submission.post_booking_question` and streams it as ordinary chat text after the booking confirms; the visitor's typed answer is attached to the booking and surfaced in the dashboard (My Appointments / Lead Workspace).

**Note:** the `book_appointment` toggle is exposed now so operators can set it; the runtime's offer-gate flip to honor it per-form is a sequenced follow-on (lambda#351 deliberately left the offer behavior unchanged to avoid a soak regression).

## Safety
- **Additive-only** schema (two optional fields) → strictly more permissive; **no existing prod config can newly fail** `validate-prod-configs`.

## Tests
- `form.schema` (+4): accept with/without question, both optional, reject >500 chars.
- `PostSubmissionConfig` component (+4): question hidden until enabled, toggle sets `book_appointment`, textarea writes the question, unchecking clears it.
- **FULL suite: 40 files / 538 pass.** typecheck + lint + build:production green. `verify-before-commit` run, no waivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)