### PR TITLE
fix(ci): staging config-builder deploys a true staging build (self-contained staging)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -112,24 +112,66 @@ jobs:
           path: dist/
           retention-days: 7
 
+  build-staging:
+    name: Build for Staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The bundle deployed to staging.config.myrecruiter.ai must talk to the
+      # STAGING config backend + bucket, not prod. esbuild defaults VITE_API_URL
+      # to the prod Lambda URL when the env var is unset (esbuild.config.mjs
+      # defineVars), so this job MUST pass the staging values explicitly —
+      # otherwise the "staging" UI writes tenant edits to the PROD config bucket.
+      # These are a public Function URL + bucket name, not secrets (mirroring
+      # esbuild's hardcoded prod default).
+      - name: Build for staging
+        run: npm run build:staging
+        env:
+          VITE_API_URL: https://zlbf6onlzdj3hqzxhrrqdxte5m0wudxf.lambda-url.us-east-1.on.aws
+          VITE_S3_BUCKET: myrecruiter-picasso-staging
+
+      - name: Upload staging build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: config-builder-staging-build
+          path: dist/
+          retention-days: 7
+
   deploy-staging:
     name: Deploy to Staging
-    needs: [lint, typecheck, test, security, build]
+    needs: [lint, typecheck, test, security, build-staging]
     permissions:
       id-token: write
       contents: read
       pull-requests: write
-    # PR preview to the staging-account bucket (CI-modernization Phase 2.3 —
-    # bucket + per-product role applied via picasso#492). Shared deploy
-    # mechanics live in the reusable workflow; serves the production-mode
-    # bundle (UI preview — pcb has one build target). No CloudFront: plain
-    # S3 website endpoint, so no invalidation needed.
+    # Deploy to the staging-account bucket (CI-modernization Phase 2.3 — bucket
+    # + per-product role applied via picasso#492). Consumes config-builder-staging-build
+    # (built with the STAGING config-API URL + bucket), so staging.config.myrecruiter.ai
+    # is a self-contained staging environment that writes to myrecruiter-picasso-staging,
+    # NOT a prod-backed UI preview.
+    # CloudFront: staging.config.myrecruiter.ai is fronted by distribution
+    # E27102WWDBF606 (acct 525, origin = this bucket's S3-website endpoint).
+    # We do NOT pass cloudfront_distribution_id here because the deploy role
+    # picasso-config-builder-deploy-staging currently has S3-only permissions
+    # (no cloudfront:CreateInvalidation). Until that grant lands, the domain
+    # serves cached content until CF TTL; invalidate manually after deploy.
     # SHA-pinned (picasso Phase-2 audit D8) — keep in sync with the pin in
     # deploy-production.yml; bump both deliberately to adopt reusable changes.
     uses: longhornrumble/picasso/.github/workflows/deploy-frontend.yml@aec1b46e8d242b3d123a8b7ff51c41fc44e635e6
     with:
       environment: staging
-      artifact_name: config-builder-build
+      artifact_name: config-builder-staging-build
       bucket: picasso-config-builder-staging
       website_url: http://picasso-config-builder-staging.s3-website-us-east-1.amazonaws.com
       comment_pr: true


### PR DESCRIPTION
## What

The `deploy-staging` job shipped the **production** build artifact (`config-builder-build`) to `staging.config.myrecruiter.ai`. Because esbuild defaults `VITE_API_URL` to the prod Lambda URL when the env var is unset, the staging bundle baked the **prod** config-API URL — so editing a tenant config in the "staging" config-builder UI actually wrote to the **prod** config bucket (`myrecruiter-picasso`). The real staging backend (`Picasso_Config_Manager` → `myrecruiter-picasso-staging`) was orphaned.

## Change

- Add a `build-staging` CI job that builds with `VITE_API_URL` = the staging config backend (`https://zlbf6onl…lambda-url`) and `VITE_S3_BUCKET=myrecruiter-picasso-staging`, uploading a `config-builder-staging-build` artifact.
- Repoint `deploy-staging` at that artifact (`needs`: `build`→`build-staging`; `artifact_name` updated).
- Prod `build` job (Build Validation gate) and the prod deploy path (`deploy-production.yml`) are **unchanged**.

Result: `staging.config.myrecruiter.ai` becomes a **self-contained** staging environment that writes to `myrecruiter-picasso-staging`, not a prod-backed UI preview.

## Verification

Ran the exact staging build locally:
```
zlbf6 (staging API, expect ≥1): 1
56mwo4 (prod API,    expect 0):  0
```
Post-deploy verifier: `aws s3 cp s3://picasso-config-builder-staging/main.js - | grep -c zlbf6` ≥1 and `grep -c 56mwo4` = 0.

## Notes / follow-ups
- `staging.config.myrecruiter.ai` is fronted by CloudFront **E27102WWDBF606** (acct 525, origin = this bucket). The deploy role `picasso-config-builder-deploy-staging` currently has **S3-only** perms, so this PR does **not** wire CF invalidation (it would fail CI). Until a `cloudfront:CreateInvalidation` grant lands, invalidate manually after deploy. (This is almost certainly why a browser-cache clear was previously needed to see staging changes.)
- `VITE_S3_BUCKET` is currently unused by the frontend (tree-shaken from the bundle); set for self-contained-staging symmetry + future-proofing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)