### PR TITLE
feat(flags): expose V5_SINGLE_PASS in the Pipeline Feature Flags panel

### DIFF
--- a/src/components/settings/FeatureFlagsSettings.tsx
+++ b/src/components/settings/FeatureFlagsSettings.tsx
@@ -21,6 +21,12 @@ interface FlagDefinition {
 
 const FLAG_DEFINITIONS: FlagDefinition[] = [
   {
+    key: 'V5_SINGLE_PASS',
+    label: 'V5 Single-Pass Turn',
+    description:
+      'One streaming call writes the reply AND selects its CTAs (coherent by construction; same ai_available vocabulary). Takes precedence over V4.0 Action Selector when both are enabled.',
+  },
+  {
     key: 'V4_ACTION_SELECTOR',
     label: 'V4.0 Action Selector',
     description: 'LLM-based CTA selection — AI picks 0-4 relevant CTAs per turn from ai_available vocabulary',
@@ -116,7 +122,9 @@ export const FeatureFlagsSettings: React.FC = () => {
           <p className="text-xs text-blue-800 dark:text-blue-300">
             <span className="font-semibold">Note:</span> When V4_ACTION_SELECTOR is enabled, the AI
             selects CTAs marked ai_available after each response. This is the preferred pipeline
-            for all new tenants.
+            for all new tenants. V5_SINGLE_PASS folds that selection into the response call itself
+            and wins over V4 when both are enabled — currently in staged rollout (staging soak on
+            the test tenant first).
           </p>
         </div>
       </CardContent>

--- a/src/components/settings/__tests__/FeatureFlagsSettings.v5.test.tsx
+++ b/src/components/settings/__tests__/FeatureFlagsSettings.v5.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * FeatureFlagsSettings — V5_SINGLE_PASS flag (V5.7 prerequisite).
+ *
+ * The V5 single-pass turn rollout flips feature_flags.V5_SINGLE_PASS per
+ * tenant, and the Config Builder is where tenant config changes start — so
+ * the flag must be toggleable from the Pipeline Feature Flags panel. These
+ * tests mirror FeatureFlagsSettings.scheduling.test.tsx: the flag renders,
+ * reflects config state, and toggling writes feature_flags.V5_SINGLE_PASS
+ * through the store.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+let mockBaseConfig: Record<string, unknown> = {};
+const mockSetState = vi.fn();
+
+vi.mock('@/store', () => ({
+  useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ config: { baseConfig: mockBaseConfig, isDirty: false } })
+  ),
+}));
+
+import { useConfigStore } from '@/store';
+import { FeatureFlagsSettings } from '../FeatureFlagsSettings';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBaseConfig = {};
+  (useConfigStore as unknown as { setState: typeof mockSetState }).setState = mockSetState;
+});
+
+describe('FeatureFlagsSettings — V5_SINGLE_PASS flag', () => {
+  it('renders the V5 flag with its description, listed above V4 (precedence order)', () => {
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByText('V5 Single-Pass Turn')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Takes precedence over V4\.0 Action Selector when both are enabled/)
+    ).toBeInTheDocument();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).toHaveAttribute('id', 'flag-V5_SINGLE_PASS');
+    expect(checkboxes[1]).toHaveAttribute('id', 'flag-V4_ACTION_SELECTOR');
+  });
+
+  it('reflects config state: unchecked when absent, checked when true', () => {
+    const { unmount } = render(<FeatureFlagsSettings />);
+    expect(screen.getByRole('checkbox', { name: /V5 Single-Pass Turn/ })).not.toBeChecked();
+    unmount();
+
+    mockBaseConfig = { feature_flags: { V5_SINGLE_PASS: true } };
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByRole('checkbox', { name: /V5 Single-Pass Turn/ })).toBeChecked();
+  });
+
+  it('toggling writes feature_flags.V5_SINGLE_PASS through the store and dirties the config', async () => {
+    mockBaseConfig = { feature_flags: {} };
+    render(<FeatureFlagsSettings />);
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /V5 Single-Pass Turn/ }));
+    expect(mockSetState).toHaveBeenCalledTimes(1);
+
+    // Apply the updater to a fake state and assert the write.
+    const updater = mockSetState.mock.calls[0][0] as (s: {
+      config: { baseConfig: { feature_flags?: Record<string, boolean> }; isDirty: boolean };
+    }) => void;
+    const state = { config: { baseConfig: { feature_flags: {} as Record<string, boolean> }, isDirty: false } };
+    updater(state);
+    expect(state.config.baseConfig.feature_flags?.V5_SINGLE_PASS).toBe(true);
+    expect(state.config.isDirty).toBe(true);
+  });
+
+  it('V4 and scheduling flags still render (no regression to existing definitions)', () => {
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByText('V4.0 Action Selector')).toBeInTheDocument();
+    expect(screen.getByText('Scheduling')).toBeInTheDocument();
+  });
+});

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -562,6 +562,8 @@ export interface TopicDefinition {
 // ============================================================================
 
 export interface FeatureFlags {
+  /** V5 single-pass turn — one streaming call writes the reply AND selects its CTAs (takes precedence over V4_ACTION_SELECTOR when both are set) */
+  V5_SINGLE_PASS?: boolean;
   /** V4.0 Action Selector — LLM-based CTA selection from ai_available vocabulary */
   V4_ACTION_SELECTOR?: boolean;
   /** Enables the v1 scheduling block — gates scheduling CTAs and the scheduling config section */


### PR DESCRIPTION
## V5.7 prerequisite — the Config Builder is where the flag flip starts

The V5 single-pass turn shipped through V5.6 (lambda#388–#394) and sits dormant on staging behind `feature_flags.V5_SINGLE_PASS`. This PR makes that flag toggleable from the Pipeline Feature Flags panel so the V5.7 staging flip on MYR384719 happens through the Config Builder staging flow (writing to `myrecruiter-picasso-staging`), not raw S3.

### Changes
- **`FLAG_DEFINITIONS`**: new "V5 Single-Pass Turn" entry, listed **above** V4.0 Action Selector — mirrors runtime precedence (the V5 branch sits before `V4_ACTION_SELECTOR` in BSH's CTA chains; V5 wins when both flags are on, which is exactly MYR384719's planned state). Contextual note updated.
- **`FeatureFlags` type**: `V5_SINGLE_PASS?: boolean`.
- **No schema change**: `featureFlagsSchema` is passthrough by design (only invariant-gating flags like `scheduling_enabled` are typed), and `V5_SINGLE_PASS` gates no builder-side invariants. **No new validation**: V5 selects from the same `ai_available` vocabulary V4.0 uses — existing CTA validations apply unchanged.
- **Tests**: `FeatureFlagsSettings.v5.test.tsx` (mirrors the scheduling-flag test pattern) — renders with description, precedence ordering pinned, reflects config state, toggling writes `feature_flags.V5_SINGLE_PASS` through the store + dirties the config, existing flags unregressed.

### Evidence
Full suite **42 files / 527 passed / 0 failed**; `typecheck`, `lint` (`--max-warnings 0`), and `build:staging` all clean locally (mirrors every pr-checks job).

### Rollout
This PR's `deploy-staging` job updates **staging.config.myrecruiter.ai** (with CloudFront invalidation) — test the toggle there against MYR384719. Prod promote stays gated (`deploy-production.yml` dispatch) per SOP, after the V5.7 staging soak. Reminder from the Phase-1 notes: the prod promote prerequisite (if-match/etag CORS on the prod Function URL) still stands for the builder generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)