### PR TITLE
feat(deploy): "Promote to Production" button (Simple UX)

### DIFF
--- a/src/components/deploy/PromoteButton.tsx
+++ b/src/components/deploy/PromoteButton.tsx
@@ -1,0 +1,118 @@
+/**
+ * PromoteButton Component
+ *
+ * Fires the gated staging→prod promotion for the loaded tenant (Simple UX):
+ * a confirm dialog → the backend dispatches the promote-tenant-config workflow,
+ * which copies this tenant's staging config to the production bucket. The Config
+ * Builder itself only ever writes staging; this button triggers the server-side,
+ * gated promotion (staging never writes prod directly).
+ */
+
+import React, { useState } from 'react';
+import { Rocket, Loader2 } from 'lucide-react';
+import {
+  Button,
+  Tooltip,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalDescription,
+  ModalFooter,
+} from '@/components/ui';
+import { useConfigStore } from '@/store';
+import { promoteConfig } from '@/lib/api/config-operations';
+
+export interface PromoteButtonProps {
+  className?: string;
+}
+
+export const PromoteButton: React.FC<PromoteButtonProps> = ({ className = '' }) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [isPromoting, setIsPromoting] = useState(false);
+
+  const tenantId = useConfigStore((state) => state.config.tenantId);
+  const addToast = useConfigStore((state) => state.ui.addToast);
+
+  const disabled = !tenantId;
+  const tooltip = tenantId
+    ? "Promote this tenant's staging config to production"
+    : 'Select a tenant first';
+
+  const handlePromote = async () => {
+    if (!tenantId) return;
+    setIsPromoting(true);
+    try {
+      const result = await promoteConfig(tenantId);
+      addToast({
+        type: 'success',
+        message: result.message || `Promotion started for ${tenantId}.`,
+      });
+      setDialogOpen(false);
+    } catch (error) {
+      addToast({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Promotion failed',
+      });
+    } finally {
+      setIsPromoting(false);
+    }
+  };
+
+  return (
+    <>
+      <Tooltip content={tooltip}>
+        <div className={`relative ${className}`}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => tenantId && setDialogOpen(true)}
+            disabled={disabled}
+          >
+            <Rocket className="w-4 h-4 lg:mr-2" />
+            <span className="hidden lg:inline">Promote</span>
+          </Button>
+        </div>
+      </Tooltip>
+
+      <Modal open={dialogOpen} onOpenChange={setDialogOpen}>
+        <ModalContent className="sm:max-w-lg">
+          <ModalHeader>
+            <ModalTitle className="flex items-center gap-2">
+              <Rocket className="w-5 h-5 text-green-600" />
+              Promote to Production
+            </ModalTitle>
+            <ModalDescription>
+              This copies the current staging config for <strong>{tenantId}</strong> to the
+              production bucket. The gated workflow validates it, backs up the current
+              production config, and writes the new one. This affects live production chat.
+            </ModalDescription>
+          </ModalHeader>
+          <ModalFooter>
+            <Button variant="ghost" onClick={() => setDialogOpen(false)} disabled={isPromoting}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handlePromote}
+              disabled={isPromoting}
+              className="bg-green-600 hover:bg-green-700 text-white dark:bg-green-700 dark:hover:bg-green-600"
+            >
+              {isPromoting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Promoting&hellip;
+                </>
+              ) : (
+                <>
+                  <Rocket className="w-4 h-4 mr-2" />
+                  Promote to Production
+                </>
+              )}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/deploy/index.ts
+++ b/src/components/deploy/index.ts
@@ -6,7 +6,9 @@
 export { DeployButton } from './DeployButton';
 export { DeployDialog } from './DeployDialog';
 export { DeploymentSummary } from './DeploymentSummary';
+export { PromoteButton } from './PromoteButton';
 
 export type { DeployButtonProps } from './DeployButton';
 export type { DeployDialogProps } from './DeployDialog';
 export type { DeploymentSummaryProps } from './DeploymentSummary';
+export type { PromoteButtonProps } from './PromoteButton';

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,7 +11,7 @@ import { TenantSelector } from '../TenantSelector';
 import { Button, Badge } from '../ui';
 import { PreviewConfigModal } from '../preview/PreviewConfigModal';
 import { ValidationSummary } from './ValidationSummary';
-import { DeployButton } from '../deploy';
+import { DeployButton, PromoteButton } from '../deploy';
 import { useConfigStore } from '@/store';
 import { useSaveShortcut } from '@/hooks/useKeyboardShortcuts';
 
@@ -132,6 +132,9 @@ export const Header: React.FC = () => {
 
             {/* Deploy Button - New Component */}
             <DeployButton />
+
+            {/* Promote to Production - fires the gated staging→prod workflow */}
+            <PromoteButton />
 
             {/* Clerk User Button */}
             <UserButton />

--- a/src/lib/api/__tests__/client.promote.test.ts
+++ b/src/lib/api/__tests__/client.promote.test.ts
@@ -1,0 +1,81 @@
+/**
+ * ConfigAPIClient.promoteConfig tests.
+ *
+ * Pins the promote request contract: POST /config/{id}/promote, the dispatch
+ * result passthrough, empty-id guard, non-ok -> ConfigAPIError, and the shared
+ * 401 -> session-expired behaviour.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ConfigAPIClient } from '../client';
+import { ConfigAPIError } from '../errors';
+
+const BASE_URL = 'http://localhost:3001';
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+describe('ConfigAPIClient.promoteConfig', () => {
+  let client: ConfigAPIClient;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new ConfigAPIClient(BASE_URL);
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to /config/{id}/promote and returns the dispatch result', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse(202, {
+        success: true,
+        tenant_id: 'TEST001',
+        message: 'Promotion dispatched.',
+        runs_url: 'https://github.com/o/r/actions/workflows/promote-tenant-config.yml',
+      })
+    );
+
+    const result = await client.promoteConfig('TEST001');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE_URL}/config/TEST001/promote`);
+    expect(init.method).toBe('POST');
+    expect(result.success).toBe(true);
+    expect(result.tenant_id).toBe('TEST001');
+    expect(result.runs_url).toContain('promote-tenant-config.yml');
+  });
+
+  it('rejects an empty tenant id without calling fetch', async () => {
+    await expect(client.promoteConfig('')).rejects.toThrow(ConfigAPIError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('maps a non-ok response (503 not configured) to a ConfigAPIError', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse(503, { error: 'Promotion Failed', message: 'Promotion is not configured' })
+    );
+
+    await expect(client.promoteConfig('TEST001')).rejects.toThrow(ConfigAPIError);
+  });
+
+  it('dispatches auth:session-expired and throws on 401', async () => {
+    const spy = vi.fn();
+    window.addEventListener('auth:session-expired', spy);
+    fetchMock.mockImplementation(() => jsonResponse(401, { error: 'Unauthorized' }));
+
+    await client.promoteConfig('TEST001').catch(() => undefined);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    window.removeEventListener('auth:session-expired', spy);
+  });
+});

--- a/src/lib/api/__tests__/config-operations.promote.test.ts
+++ b/src/lib/api/__tests__/config-operations.promote.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for the promoteConfig wrapper: tenant passthrough, result return,
+ * and the empty-id guard (client not called).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { promoteConfig } from '../config-operations';
+import { configApiClient } from '../client';
+
+vi.mock('../client', () => ({
+  configApiClient: {
+    promoteConfig: vi.fn(),
+  },
+}));
+
+describe('config-operations promoteConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(configApiClient.promoteConfig).mockResolvedValue({
+      success: true,
+      tenant_id: 'TEST_TENANT',
+      message: 'Promotion dispatched.',
+      runs_url: 'https://github.com/o/r/actions/workflows/promote-tenant-config.yml',
+    } as Awaited<ReturnType<typeof configApiClient.promoteConfig>>);
+  });
+
+  it('passes the tenant id to the client and returns the dispatch result', async () => {
+    const result = await promoteConfig('TEST_TENANT');
+
+    expect(vi.mocked(configApiClient.promoteConfig)).toHaveBeenCalledWith('TEST_TENANT');
+    expect(result.success).toBe(true);
+    expect(result.tenant_id).toBe('TEST_TENANT');
+    expect(result.runs_url).toContain('promote-tenant-config.yml');
+  });
+
+  it('rejects an empty tenant id without calling the client', async () => {
+    await expect(promoteConfig('')).rejects.toThrow();
+    expect(configApiClient.promoteConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -329,6 +329,36 @@ export class ConfigAPIClient {
   }
 
   /**
+   * Promote a tenant's staging config to production by dispatching the gated
+   * promote-tenant-config workflow. Server-side only — the browser never writes
+   * prod (staging can't write prod stores); the backend fires the workflow.
+   */
+  async promoteConfig(
+    tenantId: string
+  ): Promise<{ success: boolean; tenant_id: string; message: string; runs_url: string }> {
+    if (!tenantId || tenantId.trim() === '') {
+      throw new ConfigAPIError('INVALID_TENANT_ID', 'Tenant ID cannot be empty');
+    }
+
+    const response = await fetch(`${this.baseUrl}/config/${tenantId}/promote`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(await this.getAuthHeaders()),
+      },
+    });
+
+    if (response.status === 401) {
+      this.handle401Response();
+      throw await parseHTTPError(response);
+    }
+    if (!response.ok) {
+      throw await parseHTTPError(response);
+    }
+    return await response.json();
+  }
+
+  /**
    * Delete tenant configuration (admin operation)
    * @param full - If true, permanently deletes config, all backups, and hash mapping
    */

--- a/src/lib/api/config-operations.ts
+++ b/src/lib/api/config-operations.ts
@@ -132,6 +132,30 @@ export async function deployConfig(
   }
 }
 
+export interface PromoteConfigResponse {
+  success: boolean;
+  tenant_id: string;
+  message: string;
+  runs_url: string;
+}
+
+/**
+ * Promote a tenant's staging config to production.
+ * Fires the gated promotion workflow via the backend (staging never writes prod
+ * directly). Returns the dispatch result + a link to the workflow run.
+ */
+export async function promoteConfig(tenantId: string): Promise<PromoteConfigResponse> {
+  try {
+    if (!tenantId || tenantId.trim() === '') {
+      throw new ConfigAPIError('INVALID_TENANT_ID', 'Tenant ID is required');
+    }
+
+    return await configApiClient.promoteConfig(tenantId);
+  } catch (error) {
+    throw handleAPIError(error);
+  }
+}
+
 /**
  * Delete tenant configuration (admin operation)
  * @param full - If true, permanently deletes config, all backups, and hash mapping


### PR DESCRIPTION
## What
A **"Promote to Production"** button beside Deploy in the header. Confirm dialog → the backend dispatches the gated `promote-tenant-config` workflow, which copies this tenant's staging config to the prod bucket.

The Config Builder itself **only ever writes staging** — this fires the server-side, gated promotion (staging never writes prod directly). It's the operator-chosen **Simple UX** (confirm → promote; no in-UI diff — the workflow validates + backs up + supports version-restore).

## Changes
- `PromoteButton.tsx` — outline button + confirm `Modal` + success/error toast (mirrors `DeployButton`).
- `client.promoteConfig` / `config-operations.promoteConfig` — `POST /config/:id/promote`.
- Wired into `Header` next to `DeployButton`.

## Verification
- **typecheck + eslint clean.**
- **6/6 API-layer tests** (matching the existing `*.deploy.test.ts` pattern): `client.promote` (POST contract, result passthrough, empty-id guard/no-fetch, non-ok→`ConfigAPIError`, 401→session-expired) + `config-operations.promote` (tenant passthrough, empty-id guard).

## Depends on (inert until then)
- Backend: **lambda#398** (`POST /config/:id/promote`).
- `GITHUB_PROMOTE_TOKEN` on the staging Config Manager + the go-live workflow tweak — **until wired, the endpoint returns 503**, so shipping this early is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)