### PR TITLE
feat(deploy): live Promoting → ✓/✗ feedback on the Promote button

### DIFF
--- a/src/components/deploy/PromoteButton.tsx
+++ b/src/components/deploy/PromoteButton.tsx
@@ -1,15 +1,15 @@
 /**
  * PromoteButton Component
  *
- * Fires the gated staging→prod promotion for the loaded tenant (Simple UX):
- * a confirm dialog → the backend dispatches the promote-tenant-config workflow,
- * which copies this tenant's staging config to the production bucket. The Config
- * Builder itself only ever writes staging; this button triggers the server-side,
- * gated promotion (staging never writes prod directly).
+ * Fires the gated staging→prod promotion for the loaded tenant, then WATCHES the
+ * run so the dialog shows a live outcome: confirm → Promoting… → ✓ Promoted /
+ * ✗ Failed. The Config Builder itself only ever writes staging; the backend
+ * dispatches the workflow (which does the prod copy via OIDC) and the button
+ * polls that run's status.
  */
 
-import React, { useState } from 'react';
-import { Rocket, Loader2 } from 'lucide-react';
+import React, { useState, useRef } from 'react';
+import { Rocket, Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import {
   Button,
   Tooltip,
@@ -21,15 +21,23 @@ import {
   ModalFooter,
 } from '@/components/ui';
 import { useConfigStore } from '@/store';
-import { promoteConfig } from '@/lib/api/config-operations';
+import { promoteConfig, getPromoteStatus } from '@/lib/api/config-operations';
 
 export interface PromoteButtonProps {
   className?: string;
 }
 
+type Phase = 'idle' | 'promoting' | 'success' | 'failed';
+
+const POLL_INTERVAL_MS = 4000;
+const MAX_WAIT_MS = 4 * 60 * 1000;
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export const PromoteButton: React.FC<PromoteButtonProps> = ({ className = '' }) => {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [isPromoting, setIsPromoting] = useState(false);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const cancelRef = useRef(false);
 
   const tenantId = useConfigStore((state) => state.config.tenantId);
   const addToast = useConfigStore((state) => state.ui.addToast);
@@ -39,77 +47,159 @@ export const PromoteButton: React.FC<PromoteButtonProps> = ({ className = '' }) 
     ? "Promote this tenant's staging config to production"
     : 'Select a tenant first';
 
+  const openDialog = () => {
+    if (!tenantId) return;
+    cancelRef.current = false;
+    setPhase('idle');
+    setErrorMsg('');
+    setDialogOpen(true);
+  };
+
+  // Closing stops watching; the promote keeps running server-side either way.
+  const closeDialog = () => {
+    cancelRef.current = true;
+    setDialogOpen(false);
+    setPhase('idle');
+    setErrorMsg('');
+  };
+
   const handlePromote = async () => {
     if (!tenantId) return;
-    setIsPromoting(true);
+    cancelRef.current = false;
+    setPhase('promoting');
+    setErrorMsg('');
     try {
-      const result = await promoteConfig(tenantId);
-      addToast({
-        type: 'success',
-        message: result.message || `Promotion started for ${tenantId}.`,
-      });
-      setDialogOpen(false);
-    } catch (error) {
-      addToast({
-        type: 'error',
-        message: error instanceof Error ? error.message : 'Promotion failed',
-      });
-    } finally {
-      setIsPromoting(false);
+      const { baseline } = await promoteConfig(tenantId);
+
+      for (let waited = 0; waited < MAX_WAIT_MS; waited += POLL_INTERVAL_MS) {
+        await delay(POLL_INTERVAL_MS);
+        if (cancelRef.current) return;
+
+        let st;
+        try {
+          st = await getPromoteStatus(tenantId, baseline);
+        } catch {
+          continue; // transient network/API hiccup — keep watching
+        }
+
+        if (st.found && st.status === 'completed') {
+          if (st.conclusion === 'success') {
+            setPhase('success');
+            addToast({ type: 'success', message: `Promoted ${tenantId} to production.` });
+          } else {
+            setPhase('failed');
+            setErrorMsg(
+              `Promotion ${st.conclusion || 'did not succeed'}. Production still has the previous config — nothing partial was written (a backup is kept regardless).`
+            );
+            addToast({ type: 'error', message: `Promotion failed for ${tenantId}.` });
+          }
+          return;
+        }
+      }
+
+      if (cancelRef.current) return;
+      setPhase('failed');
+      setErrorMsg('Still running after a few minutes — it may still finish. Check again shortly.');
+    } catch (err) {
+      if (cancelRef.current) return;
+      setPhase('failed');
+      setErrorMsg(err instanceof Error ? err.message : 'Promotion failed to start.');
+      addToast({ type: 'error', message: err instanceof Error ? err.message : 'Promotion failed' });
     }
   };
+
+  const titleIcon =
+    phase === 'success' ? (
+      <CheckCircle2 className="w-5 h-5 text-green-600" />
+    ) : phase === 'failed' ? (
+      <XCircle className="w-5 h-5 text-red-600" />
+    ) : phase === 'promoting' ? (
+      <Loader2 className="w-5 h-5 text-green-600 animate-spin" />
+    ) : (
+      <Rocket className="w-5 h-5 text-green-600" />
+    );
+
+  const title =
+    phase === 'success'
+      ? 'Promoted to Production'
+      : phase === 'failed'
+        ? 'Promotion Failed'
+        : phase === 'promoting'
+          ? 'Promoting…'
+          : 'Promote to Production';
 
   return (
     <>
       <Tooltip content={tooltip}>
         <div className={`relative ${className}`}>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => tenantId && setDialogOpen(true)}
-            disabled={disabled}
-          >
+          <Button variant="outline" size="sm" onClick={openDialog} disabled={disabled}>
             <Rocket className="w-4 h-4 lg:mr-2" />
             <span className="hidden lg:inline">Promote</span>
           </Button>
         </div>
       </Tooltip>
 
-      <Modal open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Modal
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          if (!open) closeDialog();
+        }}
+      >
         <ModalContent className="sm:max-w-lg">
           <ModalHeader>
             <ModalTitle className="flex items-center gap-2">
-              <Rocket className="w-5 h-5 text-green-600" />
-              Promote to Production
+              {titleIcon}
+              {title}
             </ModalTitle>
             <ModalDescription>
-              This copies the current staging config for <strong>{tenantId}</strong> to the
-              production bucket. The gated workflow validates it, backs up the current
-              production config, and writes the new one. This affects live production chat.
+              {phase === 'idle' && (
+                <>
+                  This copies the current staging config for <strong>{tenantId}</strong> to the
+                  production bucket. The gated workflow validates it, backs up the current
+                  production config, and writes the new one. This affects live production chat.
+                </>
+              )}
+              {phase === 'promoting' && (
+                <>
+                  Copying <strong>{tenantId}</strong> to production and verifying. This usually
+                  takes a minute or two — you can leave this window open.
+                </>
+              )}
+              {phase === 'success' && (
+                <>
+                  <strong>{tenantId}</strong> is now live in production (fully in effect within
+                  ~5 minutes as caches refresh). The previous config was backed up.
+                </>
+              )}
+              {phase === 'failed' && <>{errorMsg}</>}
             </ModalDescription>
           </ModalHeader>
           <ModalFooter>
-            <Button variant="ghost" onClick={() => setDialogOpen(false)} disabled={isPromoting}>
-              Cancel
-            </Button>
-            <Button
-              variant="primary"
-              onClick={handlePromote}
-              disabled={isPromoting}
-              className="bg-green-600 hover:bg-green-700 text-white dark:bg-green-700 dark:hover:bg-green-600"
-            >
-              {isPromoting ? (
-                <>
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Promoting&hellip;
-                </>
-              ) : (
-                <>
+            {phase === 'idle' && (
+              <>
+                <Button variant="ghost" onClick={closeDialog}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={handlePromote}
+                  className="bg-green-600 hover:bg-green-700 text-white dark:bg-green-700 dark:hover:bg-green-600"
+                >
                   <Rocket className="w-4 h-4 mr-2" />
                   Promote to Production
-                </>
-              )}
-            </Button>
+                </Button>
+              </>
+            )}
+            {phase === 'promoting' && (
+              <Button variant="ghost" onClick={closeDialog}>
+                Close (keeps running)
+              </Button>
+            )}
+            {(phase === 'success' || phase === 'failed') && (
+              <Button variant="primary" onClick={closeDialog}>
+                Done
+              </Button>
+            )}
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/lib/api/__tests__/client.promote.test.ts
+++ b/src/lib/api/__tests__/client.promote.test.ts
@@ -34,13 +34,13 @@ describe('ConfigAPIClient.promoteConfig', () => {
     vi.clearAllMocks();
   });
 
-  it('POSTs to /config/{id}/promote and returns the dispatch result', async () => {
+  it('POSTs to /config/{id}/promote and returns the dispatch result with baseline', async () => {
     fetchMock.mockImplementation(() =>
       jsonResponse(202, {
         success: true,
         tenant_id: 'TEST001',
-        message: 'Promotion dispatched.',
-        runs_url: 'https://github.com/o/r/actions/workflows/promote-tenant-config.yml',
+        message: 'Promotion started.',
+        baseline: 4242,
       })
     );
 
@@ -52,7 +52,21 @@ describe('ConfigAPIClient.promoteConfig', () => {
     expect(init.method).toBe('POST');
     expect(result.success).toBe(true);
     expect(result.tenant_id).toBe('TEST001');
-    expect(result.runs_url).toContain('promote-tenant-config.yml');
+    expect(result.baseline).toBe(4242);
+  });
+
+  it('getPromoteStatus GETs /config/{id}/promote/status?after=N and returns the run outcome', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse(200, { found: true, status: 'completed', conclusion: 'success', run_url: 'u' })
+    );
+
+    const result = await client.getPromoteStatus('TEST001', 4242);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE_URL}/config/TEST001/promote/status?after=4242`);
+    expect(init.method).toBe('GET');
+    expect(result.found).toBe(true);
+    expect(result.conclusion).toBe('success');
   });
 
   it('rejects an empty tenant id without calling fetch', async () => {

--- a/src/lib/api/__tests__/config-operations.promote.test.ts
+++ b/src/lib/api/__tests__/config-operations.promote.test.ts
@@ -1,14 +1,15 @@
 /**
- * Unit tests for the promoteConfig wrapper: tenant passthrough, result return,
- * and the empty-id guard (client not called).
+ * Unit tests for the promoteConfig + getPromoteStatus wrappers: passthrough,
+ * result return, and the empty-id guard on promote.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { promoteConfig } from '../config-operations';
+import { promoteConfig, getPromoteStatus } from '../config-operations';
 import { configApiClient } from '../client';
 
 vi.mock('../client', () => ({
   configApiClient: {
     promoteConfig: vi.fn(),
+    getPromoteStatus: vi.fn(),
   },
 }));
 
@@ -18,22 +19,42 @@ describe('config-operations promoteConfig', () => {
     vi.mocked(configApiClient.promoteConfig).mockResolvedValue({
       success: true,
       tenant_id: 'TEST_TENANT',
-      message: 'Promotion dispatched.',
-      runs_url: 'https://github.com/o/r/actions/workflows/promote-tenant-config.yml',
+      message: 'Promotion started.',
+      baseline: 99,
     } as Awaited<ReturnType<typeof configApiClient.promoteConfig>>);
   });
 
-  it('passes the tenant id to the client and returns the dispatch result', async () => {
+  it('passes the tenant id to the client and returns the dispatch result + baseline', async () => {
     const result = await promoteConfig('TEST_TENANT');
 
     expect(vi.mocked(configApiClient.promoteConfig)).toHaveBeenCalledWith('TEST_TENANT');
     expect(result.success).toBe(true);
     expect(result.tenant_id).toBe('TEST_TENANT');
-    expect(result.runs_url).toContain('promote-tenant-config.yml');
+    expect(result.baseline).toBe(99);
   });
 
   it('rejects an empty tenant id without calling the client', async () => {
     await expect(promoteConfig('')).rejects.toThrow();
     expect(configApiClient.promoteConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('config-operations getPromoteStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(configApiClient.getPromoteStatus).mockResolvedValue({
+      found: true,
+      status: 'completed',
+      conclusion: 'success',
+      run_url: 'u',
+    } as Awaited<ReturnType<typeof configApiClient.getPromoteStatus>>);
+  });
+
+  it('passes tenant + baseline to the client and returns the run outcome', async () => {
+    const result = await getPromoteStatus('TEST_TENANT', 99);
+
+    expect(vi.mocked(configApiClient.getPromoteStatus)).toHaveBeenCalledWith('TEST_TENANT', 99);
+    expect(result.found).toBe(true);
+    expect(result.conclusion).toBe('success');
   });
 });

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -335,7 +335,7 @@ export class ConfigAPIClient {
    */
   async promoteConfig(
     tenantId: string
-  ): Promise<{ success: boolean; tenant_id: string; message: string; runs_url: string }> {
+  ): Promise<{ success: boolean; tenant_id: string; message: string; baseline: number }> {
     if (!tenantId || tenantId.trim() === '') {
       throw new ConfigAPIError('INVALID_TENANT_ID', 'Tenant ID cannot be empty');
     }
@@ -347,6 +347,36 @@ export class ConfigAPIClient {
         ...(await this.getAuthHeaders()),
       },
     });
+
+    if (response.status === 401) {
+      this.handle401Response();
+      throw await parseHTTPError(response);
+    }
+    if (!response.ok) {
+      throw await parseHTTPError(response);
+    }
+    return await response.json();
+  }
+
+  /**
+   * Poll the outcome of a promote run started after `after` (the dispatch
+   * baseline). found=false until the run appears; then status is
+   * queued|in_progress|completed and conclusion is success|failure|null.
+   */
+  async getPromoteStatus(
+    tenantId: string,
+    after: number
+  ): Promise<{ found: boolean; status?: string; conclusion?: string | null; run_url?: string }> {
+    const response = await fetch(
+      `${this.baseUrl}/config/${tenantId}/promote/status?after=${encodeURIComponent(String(after))}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await this.getAuthHeaders()),
+        },
+      }
+    );
 
     if (response.status === 401) {
       this.handle401Response();

--- a/src/lib/api/config-operations.ts
+++ b/src/lib/api/config-operations.ts
@@ -136,13 +136,24 @@ export interface PromoteConfigResponse {
   success: boolean;
   tenant_id: string;
   message: string;
-  runs_url: string;
+  /** Newest run id before dispatch — pass to getPromoteStatus to poll outcome. */
+  baseline: number;
+}
+
+export interface PromoteStatusResponse {
+  /** false until the run started by this promote appears. */
+  found: boolean;
+  /** queued | in_progress | completed */
+  status?: string;
+  /** success | failure | cancelled | null (null until completed) */
+  conclusion?: string | null;
+  run_url?: string;
 }
 
 /**
  * Promote a tenant's staging config to production.
  * Fires the gated promotion workflow via the backend (staging never writes prod
- * directly). Returns the dispatch result + a link to the workflow run.
+ * directly). Returns the dispatch result incl. the run baseline for polling.
  */
 export async function promoteConfig(tenantId: string): Promise<PromoteConfigResponse> {
   try {
@@ -151,6 +162,20 @@ export async function promoteConfig(tenantId: string): Promise<PromoteConfigResp
     }
 
     return await configApiClient.promoteConfig(tenantId);
+  } catch (error) {
+    throw handleAPIError(error);
+  }
+}
+
+/**
+ * Poll the outcome of a promote run (see promoteConfig's baseline).
+ */
+export async function getPromoteStatus(
+  tenantId: string,
+  after: number
+): Promise<PromoteStatusResponse> {
+  try {
+    return await configApiClient.getPromoteStatus(tenantId, after);
   } catch (error) {
     throw handleAPIError(error);
   }


### PR DESCRIPTION
Replaces the fire-and-forget "dispatched" toast with **live outcome in the dialog**: confirm → **Promoting…** (spinner) → **✓ Promoted to Production** / **✗ Promotion Failed**. No links — visual success/failure in the app, as requested.

## How
- `promoteConfig` returns the dispatch **baseline** run id; `getPromoteStatus(tenant, after)` polls `GET /config/:id/promote/status`.
- `PromoteButton` is a small state machine (idle/promoting/success/failed), polling every 4s (≤4 min) with a cancel ref (closing the dialog stops watching; the promote still completes server-side). Success/failure also toast.

## Verification
typecheck + eslint clean · **8/8 API-layer tests** (promote returns baseline, status GET contract, empty-id guard, wrappers).

Backend: lambda#399 (the `/promote/status` endpoint + baseline correlation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)