### PR TITLE
feat(types): messenger_behavior.escalation_email (C2 v1.1 additive, M6a)

### DIFF
--- a/src/lib/schemas/tenant.schema.ts
+++ b/src/lib/schemas/tenant.schema.ts
@@ -242,6 +242,7 @@ export const messengerChannelOverrideSchema = z.object({
 
 export const messengerBehaviorSchema = z.object({
   tone_override: z.string().optional(),
+  escalation_email: z.string().email().optional(),
   model_id: z.string().optional(),
   max_history_turns: z.number().int().positive().optional(),
   strings: messengerStringsSchema.optional(),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -691,6 +691,8 @@ export interface MessengerWelcomeConfig {
 export interface MessengerBehaviorConfig {
   /** Replaces tone_prompt in the Messenger prompt when set (replace, not concatenate — C6) */
   tone_override?: string;
+  /** Staff email notified on human-escalation (M6a; C2 v1.1 additive). Business contact, not consumer PII — the email body is content-free by G-P2 invariant. */
+  escalation_email?: string;
   /** Messenger model override (C6 precedence: channel override → this → config.model_id → processor default) */
   model_id?: string;
   /** History window in turn pairs; default 5 */


### PR DESCRIPTION
Additive optional field for the M6a escalation notify leg (lambda-repo PR pairs). G-P2 advisory: business-contact class, not a consumer-PII destination in v1 — the email body is content-free by a tested invariant. Zod mirror validates email shape. tsc clean; vitest 504/504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)