### PR TITLE
feat(settings): MESSENGER_CHANNEL feature-flag toggle (Messenger Product Surface T1)

### DIFF
--- a/src/components/settings/FeatureFlagsSettings.tsx
+++ b/src/components/settings/FeatureFlagsSettings.tsx
@@ -36,6 +36,11 @@ const FLAG_DEFINITIONS: FlagDefinition[] = [
     label: 'Scheduling',
     description: 'Enables the v1 scheduling block — required for start_scheduling/resume_scheduling CTAs and the scheduling configuration section',
   },
+  {
+    key: 'MESSENGER_CHANNEL',
+    label: 'Messenger Channel',
+    description: 'Enables the Facebook Messenger / Instagram DM channel — V5-driven replies, human escalation, forms, and scheduling for connected Meta pages. Requires a connected page and messenger_behavior config to be useful.',
+  },
 ];
 
 // ============================================================================

--- a/src/components/settings/__tests__/FeatureFlagsSettings.messenger.test.tsx
+++ b/src/components/settings/__tests__/FeatureFlagsSettings.messenger.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * FeatureFlagsSettings — MESSENGER_CHANNEL flag (Messenger Product Surface T1).
+ *
+ * MESSENGER_CHANNEL gates the entire Meta Messenger / Instagram DM layer in the
+ * lambda pipeline (V5 prompt, escalation, forms, scheduling). The type already
+ * exists (config contract C2, landed by the sibling program's M0); this flag is
+ * the Config Builder toggle that lets an operator turn it on per tenant. These
+ * tests mirror FeatureFlagsSettings.v5.test.tsx: the flag renders, reflects
+ * config state, and toggling writes the EXACT key feature_flags.MESSENGER_CHANNEL
+ * through the store.
+ *
+ * The exact-key assertion is load-bearing: FeatureFlags carries a string index
+ * signature (config.ts), so `keyof FeatureFlags` is `string` and a typo in the
+ * flag key would compile clean. The test is the only guardrail against that.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+let mockBaseConfig: Record<string, unknown> = {};
+const mockSetState = vi.fn();
+
+vi.mock('@/store', () => ({
+  useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ config: { baseConfig: mockBaseConfig, isDirty: false } })
+  ),
+}));
+
+import { useConfigStore } from '@/store';
+import { FeatureFlagsSettings } from '../FeatureFlagsSettings';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBaseConfig = {};
+  (useConfigStore as unknown as { setState: typeof mockSetState }).setState = mockSetState;
+});
+
+describe('FeatureFlagsSettings — MESSENGER_CHANNEL flag', () => {
+  it('renders the Messenger Channel flag with its description and a stable checkbox id', () => {
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByText('Messenger Channel')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Facebook Messenger \/ Instagram DM channel/)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Messenger Channel/ })).toHaveAttribute(
+      'id',
+      'flag-MESSENGER_CHANNEL'
+    );
+  });
+
+  it('reflects config state: unchecked when absent, checked when true', () => {
+    const { unmount } = render(<FeatureFlagsSettings />);
+    expect(screen.getByRole('checkbox', { name: /Messenger Channel/ })).not.toBeChecked();
+    unmount();
+
+    mockBaseConfig = { feature_flags: { MESSENGER_CHANNEL: true } };
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByRole('checkbox', { name: /Messenger Channel/ })).toBeChecked();
+  });
+
+  it('toggling writes the exact key feature_flags.MESSENGER_CHANNEL through the store and dirties the config', async () => {
+    mockBaseConfig = { feature_flags: {} };
+    render(<FeatureFlagsSettings />);
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /Messenger Channel/ }));
+    expect(mockSetState).toHaveBeenCalledTimes(1);
+
+    const updater = mockSetState.mock.calls[0][0] as (s: {
+      config: { baseConfig: { feature_flags?: Record<string, boolean> }; isDirty: boolean };
+    }) => void;
+    const state = { config: { baseConfig: { feature_flags: {} as Record<string, boolean> }, isDirty: false } };
+    updater(state);
+    // Assert the literal key string — not merely "a boolean changed".
+    expect(state.config.baseConfig.feature_flags?.MESSENGER_CHANNEL).toBe(true);
+    expect(Object.keys(state.config.baseConfig.feature_flags ?? {})).toContain('MESSENGER_CHANNEL');
+    expect(state.config.isDirty).toBe(true);
+  });
+
+  it('existing flags still render (no regression to prior definitions)', () => {
+    render(<FeatureFlagsSettings />);
+    expect(screen.getByText('V5 Single-Pass Turn')).toBeInTheDocument();
+    expect(screen.getByText('V4.0 Action Selector')).toBeInTheDocument();
+    expect(screen.getByText('Scheduling')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What
Adds the **Messenger Channel** toggle to the Pipeline Feature Flags panel (`FLAG_DEFINITIONS`), plus a 4-assertion test.

This is **T1** of the [Messenger Product Surface](../../docs/roadmap/MESSENGER_PRODUCT_SURFACE.md) program — the day-one unblock.

## Why now / why this is safe
- The `FeatureFlags.MESSENGER_CHANNEL` **type already exists** on main (config contract C2, landed by the sibling program's M0) — this only adds the UI toggle.
- `feature_flags` already round-trips whole through `getMergedConfig` and is already in the Config Manager `EDITABLE_SECTIONS`, so **zero backend change** is needed.
- Once merged + deployed to staging CB, an operator can flip `MESSENGER_CHANNEL` on `MYR384719` and the existing IG "speak with staff" escalation email fires via the env-default bridge.

## Test
`FeatureFlagsSettings.messenger.test.tsx` (4): renders + stable id; reflects config state (absent/true); toggling writes the **exact key** `feature_flags.MESSENGER_CHANNEL` + dirties config; existing flags still render (no regression). The exact-key assertion is the only guardrail against a typo, since `FeatureFlags`'s string index signature makes `keyof` = `string`.

## Verification
typecheck clean · eslint clean · 8/8 tests (4 new + 4 v5 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)