### PR TITLE
feat(config): emit messenger_behavior from getMergedConfig (Messenger Product Surface T2b)

### DIFF
--- a/src/__tests__/integration/mergePayload.sections.test.tsx
+++ b/src/__tests__/integration/mergePayload.sections.test.tsx
@@ -119,6 +119,7 @@ describe('merge payload contract (getMergedConfig vs shared section contract)', 
       },
       topic_definitions: [{ id: 't1', label: 'T1' }],
       notification_settings: { enabled: true },
+      messenger_behavior: { escalation_email: 'notify@myrecruiter.ai' },
     } as unknown as Partial<TenantConfig>;
 
     const testConfig = createTestTenantConfig('FULL_TENANT', overrides) as TenantConfig &
@@ -152,5 +153,30 @@ describe('merge payload contract (getMergedConfig vs shared section contract)', 
         `getMergedConfig emitted "${section}" but CB has no editor for it`
       ).toBe(false);
     }
+  });
+
+  it('FORWARD-COMPAT: an old-shape config without messenger_behavior round-trips without emitting the key (Schema Discipline)', async () => {
+    const { result } = renderHook(() => useConfigStore());
+    const mockS3 = createMockS3API();
+
+    // Baseline test config has no messenger_behavior — the pre-Messenger shape.
+    const testConfig = createTestTenantConfig('OLD_TENANT') as TenantConfig &
+      Record<string, unknown>;
+    expect(testConfig).not.toHaveProperty('messenger_behavior');
+
+    mockS3._setMockConfig('OLD_TENANT', testConfig);
+    vi.mocked(configOps.loadConfig).mockImplementation((tenantId) =>
+      mockS3.loadConfig(tenantId)
+    );
+
+    await act(async () => {
+      await result.current.config.loadConfig('OLD_TENANT');
+    });
+
+    const merged = result.current.config.getMergedConfig();
+    // No crash, and the conditional emit omits the absent section entirely
+    // (rather than writing messenger_behavior: undefined).
+    expect(merged).not.toBeNull();
+    expect(merged).not.toHaveProperty('messenger_behavior');
   });
 });

--- a/src/lib/contracts/config_sections_contract.json
+++ b/src/lib/contracts/config_sections_contract.json
@@ -1,6 +1,6 @@
 {
   "_doc": "Two-tier section contract between the Config Builder (getMergedConfig, src/store/slices/config.ts) and Picasso_Config_Manager (EDITABLE_SECTIONS, mergeStrategy.mjs). Messenger Product Surface P0b. cm_accepts = every section the server merge will accept (== EDITABLE_SECTIONS). cb_must_emit = the subset the Config Builder owns a UI/emit path for and MUST be capable of emitting (cm_accepts minus intent_definitions/monitor, which CB has no editor for — Landmine 4). CROSS-REPO CAVEAT: this file is duplicated verbatim in Lambdas/lambda/Picasso_Config_Manager/config_sections_contract.json. The two repos have separate CI; each test only self-validates its own copy. There is NO automated check that the copies match — reconcile by manual diff whenever either side changes a section. Proportionate for a solo-operator tool; stated plainly rather than implying enforcement that does not exist.",
-  "_version": "1.0.0",
+  "_version": "1.1.0",
   "cm_accepts": [
     "programs",
     "conversational_forms",
@@ -20,7 +20,8 @@
     "topic_definitions",
     "form_settings",
     "monitor",
-    "notification_settings"
+    "notification_settings",
+    "messenger_behavior"
   ],
   "cb_must_emit": [
     "programs",
@@ -39,7 +40,8 @@
     "feature_flags",
     "topic_definitions",
     "form_settings",
-    "notification_settings"
+    "notification_settings",
+    "messenger_behavior"
   ],
   "cb_not_emitted": {
     "_doc": "In cm_accepts but NOT cb_must_emit — the server accepts them, but the Config Builder has no editor and never sends them. Documented so the completeness test can exclude them without hiding the gap.",

--- a/src/store/slices/config.ts
+++ b/src/store/slices/config.ts
@@ -435,6 +435,9 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         ? { form_settings: (state.config.baseConfig as TenantConfig & { form_settings?: unknown }).form_settings }
         : {}),
       ...(state.config.baseConfig.notification_settings && { notification_settings: state.config.baseConfig.notification_settings }),
+      // Messenger channel behavior tuning (contract C2; server-editable per T2a).
+      // Conditional emit — old configs without the section round-trip unchanged.
+      ...(state.config.baseConfig.messenger_behavior && { messenger_behavior: state.config.baseConfig.messenger_behavior }),
     };
 
     // Post-process forms: map post_submission.fulfillment → root-level fulfillment


### PR DESCRIPTION
## What
Adds the conditional `getMergedConfig` emit line for `messenger_behavior` and syncs the CB copy of the section contract to `cm_accepts` (20) / `cb_must_emit` (18).

**T2b** of the [Messenger Product Surface](https://github.com/longhornrumble/picasso/blob/main/docs/roadmap/MESSENGER_PRODUCT_SURFACE.md). Consumes **T2a** (already live on staging — `Deploy Picasso_Config_Manager` ✓).

## Why
The `MessengerBehaviorConfig` type + `TenantConfig.messenger_behavior?` already exist (M0), and T2a made the server accept the section — but without a `getMergedConfig` emit line, CB edits would still silently never persist (**Landmine 1**). This is that line.

## Tests
- Completeness fixture now populates `messenger_behavior`, so a missing emit line fails the Landmine-1 guard — **proven via red/green** (removing the line fails on `messenger_behavior`; restoring passes).
- New **forward-compat** test: an old-shape config without the section round-trips without emitting `messenger_behavior: undefined` (Schema Discipline).
- CB contract copy confirmed **byte-identical** to the lambda copy (`diff -q`).

Full suite: **511/511** · typecheck clean · eslint clean.

## Verification note
The live save→deploy→S3 round-trip through the Clerk-authed staging CB is exercised by the operator at the **T2c** UI DONE (browser Clerk session; not CLI-mintable). The emit logic itself is proven by the integration test + red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)