### PR TITLE
fix(channels): fail loud when VITE_CHANNELS_API_URL is unset (Messenger Product Surface T3a / G6)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -125,6 +125,13 @@ jobs:
 
       - name: Build for production
         run: npm run build:production
+        env:
+          # Meta_OAuth_Handler Function URL in the PROD account (614). The
+          # component no longer hardcodes this — every build must declare its
+          # channels API explicitly (staging value is set in pr-checks.yml), so
+          # a build that forgets fails loud instead of silently using prod.
+          # Public Function URL, not a secret.
+          VITE_CHANNELS_API_URL: https://qwxscz5w6lkzjmhcpyhewijize0jpzzx.lambda-url.us-east-1.on.aws
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/src/components/settings/ChannelsSettings.tsx
+++ b/src/components/settings/ChannelsSettings.tsx
@@ -50,8 +50,13 @@ function InstagramIcon(props: React.SVGProps<SVGSVGElement>) {
 
 // `import.meta.env` can be undefined under ESBuild's dev pipeline (unlike Vite's
 // auto-injection), which crashed module load and blocked the whole app from
-// rendering. Guard against it so the fallback URL is always reachable.
-const CHANNELS_API_URL = (typeof import.meta !== 'undefined' && import.meta.env?.VITE_CHANNELS_API_URL) || 'https://qwxscz5w6lkzjmhcpyhewijize0jpzzx.lambda-url.us-east-1.on.aws';
+// rendering. Guard against that. There is deliberately NO hardcoded prod URL
+// fallback: every build must declare VITE_CHANNELS_API_URL explicitly (staging
+// in pr-checks.yml, prod in deploy-production.yml). When it is unset the connect
+// actions fail loud (below) rather than silently driving the PROD OAuth handler
+// from a staging/dev build — the G6 bug this replaces.
+const CHANNELS_API_URL = (typeof import.meta !== 'undefined' && import.meta.env?.VITE_CHANNELS_API_URL) || '';
+const CHANNELS_API_CONFIGURED = CHANNELS_API_URL.length > 0;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -287,6 +292,12 @@ export const ChannelsSettings: React.FC = () => {
 
   const handleConnect = useCallback(async () => {
     if (!tenantId) return;
+    if (!CHANNELS_API_CONFIGURED) {
+      setError(
+        'Channel connect is not configured for this build (VITE_CHANNELS_API_URL is unset). No request was sent.'
+      );
+      return;
+    }
     setError(null);
     setConnectLoading(true);
 
@@ -332,6 +343,12 @@ export const ChannelsSettings: React.FC = () => {
   const handleToggle = useCallback(
     async (enabled: boolean) => {
       if (!tenantId) return;
+      if (!CHANNELS_API_CONFIGURED) {
+        setError(
+          'Channel management is not configured for this build (VITE_CHANNELS_API_URL is unset). No request was sent.'
+        );
+        return;
+      }
       setError(null);
       setToggleLoading(true);
 
@@ -375,6 +392,12 @@ export const ChannelsSettings: React.FC = () => {
 
   const handleDisconnect = useCallback(async () => {
     if (!tenantId) return;
+    if (!CHANNELS_API_CONFIGURED) {
+      setError(
+        'Channel management is not configured for this build (VITE_CHANNELS_API_URL is unset). No request was sent.'
+      );
+      return;
+    }
     const confirmed = window.confirm(
       'Are you sure you want to disconnect this Facebook Page? Messages from Messenger will no longer be routed to Picasso.'
     );
@@ -427,6 +450,21 @@ export const ChannelsSettings: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      {/* Not-configured notice — connect/manage are disabled and fail loud
+          rather than silently reaching the prod OAuth handler (G6). */}
+      {!CHANNELS_API_CONFIGURED && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-300"
+        >
+          <XCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>
+            Channel connect is not configured for this build (<code>VITE_CHANNELS_API_URL</code> is
+            unset). Connecting and managing channels are disabled here.
+          </span>
+        </div>
+      )}
+
       {/* Global error banner */}
       {error && (
         <div

--- a/src/components/settings/__tests__/ChannelsSettings.failLoud.test.tsx
+++ b/src/components/settings/__tests__/ChannelsSettings.failLoud.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * ChannelsSettings — fail-loud when VITE_CHANNELS_API_URL is unset (T3a / G6).
+ *
+ * The component no longer hardcodes the PROD OAuth URL as a fallback. When a
+ * build fails to declare VITE_CHANNELS_API_URL, connect/manage must fail loud
+ * (visible notice + no network call) rather than silently driving the prod
+ * OAuth handler from a staging/dev build.
+ *
+ * The URL is resolved into a module-level const, so this file resets modules and
+ * re-imports the component with the env stubbed empty (setup.ts stubs a default
+ * for every other test).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockSetState = vi.fn();
+vi.mock('@/store', () => ({
+  useConfigStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) =>
+      selector({ config: { tenantId: 'TENANT123', baseConfig: {}, isDirty: false } })
+    ),
+    { setState: (fn: unknown) => mockSetState(fn) }
+  ),
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ getToken: vi.fn().mockResolvedValue('mock-jwt-token') }),
+}));
+
+const mockFetch = vi.fn();
+
+describe('ChannelsSettings — fail-loud when channels API is not configured', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('VITE_CHANNELS_API_URL', '');
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function renderUnconfigured() {
+    const { ChannelsSettings } = await import('../ChannelsSettings');
+    return render(<ChannelsSettings />);
+  }
+
+  it('shows a not-configured notice', async () => {
+    await renderUnconfigured();
+    expect(screen.getByText(/not configured for this build/i)).toBeInTheDocument();
+    expect(screen.getByText(/VITE_CHANNELS_API_URL/)).toBeInTheDocument();
+  });
+
+  it('connect click fails loud and sends NO network request', async () => {
+    const user = userEvent.setup();
+    await renderUnconfigured();
+
+    await user.click(screen.getByRole('button', { name: /connect a facebook page/i }));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(screen.getByText(/No request was sent/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/__tests__/ChannelsSettings.test.tsx
+++ b/src/components/settings/__tests__/ChannelsSettings.test.tsx
@@ -280,7 +280,8 @@ describe('ChannelsSettings', () => {
     // The handler only accepts messages from the Channels API origin (where the
     // OAuth callback page is served). With VITE_CHANNELS_API_URL unset in tests,
     // the component falls back to its hardcoded default — mirror that origin here.
-    const CHANNELS_ORIGIN = 'https://qwxscz5w6lkzjmhcpyhewijize0jpzzx.lambda-url.us-east-1.on.aws';
+    // Must match the VITE_CHANNELS_API_URL the test env injects (src/test/setup.ts).
+    const CHANNELS_ORIGIN = 'https://channels.test.example';
 
     const payload = {
       page_id: '222',

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom';
-import { expect, afterEach } from 'vitest';
+import { expect, afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
+
+// A real build always declares VITE_CHANNELS_API_URL (staging in pr-checks.yml,
+// prod in deploy-production.yml). Give the test env a default so ChannelsSettings
+// behaves as "configured" by default; the fail-loud (unset) path is exercised in
+// ChannelsSettings.failLoud.test.tsx via vi.stubEnv('') + module reset.
+vi.stubEnv('VITE_CHANNELS_API_URL', 'https://channels.test.example');
 
 // Cleanup after each test case
 afterEach(() => {


### PR DESCRIPTION
## What
Removes the hardcoded **prod** OAuth Lambda URL fallback from `ChannelsSettings`. When `VITE_CHANNELS_API_URL` is unset, connect/toggle/disconnect now **fail loud** (visible notice + no network call) instead of silently driving the prod `Meta_OAuth_Handler` from a staging/dev build (the **G6** bug).

**T3a** of the [Messenger Product Surface](https://github.com/longhornrumble/picasso/blob/main/docs/roadmap/MESSENGER_PRODUCT_SURFACE.md).

## Why the deploy-production.yml change is required
esbuild defaults `VITE_CHANNELS_API_URL` to `''`, and the prod build set no value — so the component's hardcoded prod URL was the *actual* prod fallback. Removing it without injecting the prod URL in `deploy-production.yml` would break prod connect. So every build now declares the URL explicitly: staging in `pr-checks.yml` (already present), prod in `deploy-production.yml` (added here).

## Tests
- Existing `ChannelsSettings` suite still green — `setup.ts` injects a default test URL; `CHANNELS_ORIGIN` aligned.
- New `ChannelsSettings.failLoud.test.tsx`: unset env → not-configured notice + connect click sends **no** request (`resetModules` + `stubEnv('')`).
- Full suite **517** · typecheck + eslint clean · `deploy-production.yml` YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)