### PR TITLE
fix(settings): re-land Messenger product page (T2c content that PR #87 dropped)

### DIFF
--- a/src/components/settings/FeatureFlagsSettings.tsx
+++ b/src/components/settings/FeatureFlagsSettings.tsx
@@ -36,11 +36,9 @@ const FLAG_DEFINITIONS: FlagDefinition[] = [
     label: 'Scheduling',
     description: 'Enables the v1 scheduling block — required for start_scheduling/resume_scheduling CTAs and the scheduling configuration section',
   },
-  {
-    key: 'MESSENGER_CHANNEL',
-    label: 'Messenger Channel',
-    description: 'Enables the Facebook Messenger / Instagram DM channel — V5-driven replies, human escalation, forms, and scheduling for connected Meta pages. Requires a connected page and messenger_behavior config to be useful.',
-  },
+  // MESSENGER_CHANNEL intentionally lives on the dedicated Messenger product page
+  // (Settings → Messenger), not here. Pattern rule: when a flag graduates to a
+  // product page, its flat toggle is removed so there is exactly one control.
 ];
 
 // ============================================================================

--- a/src/components/settings/MessengerSettings.tsx
+++ b/src/components/settings/MessengerSettings.tsx
@@ -1,0 +1,248 @@
+/**
+ * MessengerSettings — the Messenger product page (Messenger Product Surface T2c).
+ *
+ * This is the FIRST "product" grouping under the hybrid IA: a single page that
+ * bundles a product's enable flag + its behavior config + a readiness checklist.
+ * It sets the pattern Forms/Scheduling inherit in a later program, so its shape
+ * is deliberately generalizable:
+ *
+ *   product page = [enable toggle] + [config fields] + [readiness checklist of
+ *   the preconditions THIS page can authoritatively determine from config,
+ *   plus explicit deferral for state owned elsewhere]
+ *
+ * Readiness authority (D1 rule): the checklist reports the flag and escalation
+ * recipient (config-authoritative) plus a display-only connection row that reads
+ * the S3 `channels.*` mirror exactly as the Channels tab does. D1 forbids runtime
+ * code from GATING on that mirror (DDB is the source of truth) — it does not
+ * forbid CB from DISPLAYING last-known connection metadata. Connecting/
+ * disconnecting stays in the Channels tab / portal; this page never mutates it.
+ *
+ * All edits mutate the whole messenger_behavior object in baseConfig; getMergedConfig
+ * emits the complete section and Config Manager wholesale-replaces it — so the
+ * always-send-whole discipline is satisfied by construction (no partial patch).
+ */
+
+import React from 'react';
+import { CheckCircle2, Circle, ExternalLink } from 'lucide-react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  Input,
+  Textarea,
+} from '@/components/ui';
+import { useConfigStore } from '@/store';
+import type { FeatureFlags, MessengerBehaviorConfig, MessengerStrings } from '@/types/config';
+
+// ---------------------------------------------------------------------------
+// Readiness checklist
+// ---------------------------------------------------------------------------
+
+interface ReadinessItem {
+  label: string;
+  done: boolean;
+  detail: string;
+}
+
+const ReadinessRow: React.FC<ReadinessItem> = ({ label, done, detail }) => (
+  <div className="flex items-start gap-3 py-2">
+    {done ? (
+      <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" aria-hidden="true" />
+    ) : (
+      <Circle className="h-5 w-5 shrink-0 text-gray-300 dark:text-gray-600" aria-hidden="true" />
+    )}
+    <div>
+      <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+        {label}
+        <span className="sr-only">{done ? ' — done' : ' — not done'}</span>
+      </p>
+      <p className="text-xs text-gray-500 dark:text-gray-400">{detail}</p>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const MessengerSettings: React.FC = () => {
+  const baseConfig = useConfigStore((state) => state.config.baseConfig);
+
+  const featureFlags: FeatureFlags = baseConfig?.feature_flags ?? {};
+  const behavior: MessengerBehaviorConfig = baseConfig?.messenger_behavior ?? {};
+  const strings: MessengerStrings = behavior.strings ?? {};
+
+  const flagOn = featureFlags.MESSENGER_CHANNEL === true;
+  const escalationEmail = behavior.escalation_email ?? '';
+  const disclosureLine = strings.disclosure_line ?? '';
+  const toneOverride = behavior.tone_override ?? '';
+
+  // Connection state: read the S3 channels mirror the same way the Channels tab
+  // does — display-only, never for gating (D1 authority rule: DDB is the runtime
+  // source of truth; the mirror is last-known display metadata). Connecting/
+  // disconnecting stays in the Channels tab / portal, not here.
+  const channels = baseConfig?.channels;
+  const messengerPage = channels?.messenger?.page_name;
+  const instagramConnected = Boolean(channels?.instagram);
+  const anyConnected = Boolean(channels?.messenger) || instagramConnected;
+
+  const setFlag = (value: boolean) => {
+    useConfigStore.setState((state) => {
+      if (!state.config.baseConfig) return;
+      if (!state.config.baseConfig.feature_flags) state.config.baseConfig.feature_flags = {};
+      state.config.baseConfig.feature_flags.MESSENGER_CHANNEL = value;
+      state.config.isDirty = true;
+    });
+  };
+
+  // Mutate the messenger_behavior object as a whole (created lazily). getMergedConfig
+  // emits the entire section; the server wholesale-replaces it.
+  const updateBehavior = (patch: Partial<MessengerBehaviorConfig>) => {
+    useConfigStore.setState((state) => {
+      if (!state.config.baseConfig) return;
+      if (!state.config.baseConfig.messenger_behavior) state.config.baseConfig.messenger_behavior = {};
+      Object.assign(state.config.baseConfig.messenger_behavior, patch);
+      state.config.isDirty = true;
+    });
+  };
+
+  const updateString = (key: keyof MessengerStrings, value: string) => {
+    useConfigStore.setState((state) => {
+      if (!state.config.baseConfig) return;
+      if (!state.config.baseConfig.messenger_behavior) state.config.baseConfig.messenger_behavior = {};
+      if (!state.config.baseConfig.messenger_behavior.strings) {
+        state.config.baseConfig.messenger_behavior.strings = {};
+      }
+      state.config.baseConfig.messenger_behavior.strings[key] = value;
+      state.config.isDirty = true;
+    });
+  };
+
+  const recipientSet = escalationEmail.trim().length > 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Enable */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Messenger Channel</CardTitle>
+          <CardDescription>
+            Facebook Messenger &amp; Instagram DM — one V5-driven channel with human escalation,
+            forms, and scheduling for connected Meta pages. Turning this on gates all Messenger
+            behavior for this tenant.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <label className="flex items-start justify-between gap-4">
+            <div>
+              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Enable the Messenger channel
+              </span>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Sets <code>feature_flags.MESSENGER_CHANNEL</code>. Off = the legacy path is
+                byte-identical (no Messenger behavior runs).
+              </p>
+            </div>
+            <input
+              id="messenger-enable"
+              type="checkbox"
+              checked={flagOn}
+              onChange={(e) => setFlag(e.target.checked)}
+              className="w-5 h-5 rounded border-gray-300 dark:border-gray-600 text-primary focus:ring-primary cursor-pointer mt-0.5"
+            />
+          </label>
+        </CardContent>
+      </Card>
+
+      {/* Escalation */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Human escalation</CardTitle>
+          <CardDescription>
+            When a visitor asks to speak with a person, the bot pauses and this recipient is
+            notified so staff can reply from the Business Suite inbox. The email body is
+            content-free by design (no transcript).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Input
+            label="Escalation recipient email"
+            type="email"
+            value={escalationEmail}
+            onChange={(e) => updateBehavior({ escalation_email: e.target.value })}
+            placeholder="notify@myrecruiter.ai"
+            helperText="Staff address notified on human-escalation. Must be a verified SES identity. When unset, the platform falls back to its ESCALATION_EMAIL default."
+          />
+        </CardContent>
+      </Card>
+
+      {/* Behavior */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Messenger behavior</CardTitle>
+          <CardDescription>
+            Optional per-tenant overrides. Leave blank to use the platform defaults.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            label="Disclosure line"
+            value={disclosureLine}
+            onChange={(e) => updateString('disclosure_line', e.target.value)}
+            placeholder="You're chatting with an automated assistant."
+            helperText="Shown on the first turn of each session (bot-disclosure requirement)."
+          />
+          <Textarea
+            label="Tone override"
+            value={toneOverride}
+            onChange={(e) => updateBehavior({ tone_override: e.target.value })}
+            placeholder="Leave blank to use the tenant's standard tone prompt."
+            helperText="Replaces the tone prompt for Messenger only (does not concatenate)."
+            rows={3}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Readiness */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Readiness</CardTitle>
+          <CardDescription>
+            What still needs to be set for Messenger to work end-to-end on this tenant.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ReadinessRow
+            label="Channel enabled"
+            done={flagOn}
+            detail={flagOn ? 'MESSENGER_CHANNEL is on.' : 'Turn on the Messenger channel above.'}
+          />
+          <ReadinessRow
+            label="Escalation recipient set"
+            done={recipientSet}
+            detail={
+              recipientSet
+                ? `Notifications go to ${escalationEmail}.`
+                : 'Set an escalation recipient above (otherwise the platform default is used).'
+            }
+          />
+          <ReadinessRow
+            label="Facebook / Instagram page connected"
+            done={anyConnected}
+            detail={
+              anyConnected
+                ? `Connected${messengerPage ? `: ${messengerPage}` : ''}${instagramConnected ? ' (Instagram linked)' : ''}. Manage in the Channels tab.`
+                : 'No page connected yet — connect one in the Channels tab (or, for tenants, the admin portal).'
+            }
+          />
+          <p className="mt-2 flex items-center gap-1 text-xs text-gray-400">
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            Connection is managed in the Channels tab; this reflects last-known connection metadata.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/settings/__tests__/MessengerSettings.test.tsx
+++ b/src/components/settings/__tests__/MessengerSettings.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * MessengerSettings — Messenger product page (Messenger Product Surface T2c).
+ *
+ * Covers the pattern this page seeds: enable toggle + config fields + readiness
+ * checklist. Load-bearing assertions: the flag writes the EXACT key
+ * feature_flags.MESSENGER_CHANNEL; escalation writes messenger_behavior.escalation_email;
+ * readiness reflects config-authoritative state (flag + recipient) and does NOT
+ * fabricate connection status.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+let mockBaseConfig: Record<string, unknown> | null = {};
+const mockSetState = vi.fn();
+
+vi.mock('@/store', () => ({
+  useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ config: { baseConfig: mockBaseConfig, isDirty: false } })
+  ),
+}));
+
+import { useConfigStore } from '@/store';
+import { MessengerSettings } from '../MessengerSettings';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBaseConfig = {};
+  (useConfigStore as unknown as { setState: typeof mockSetState }).setState = mockSetState;
+});
+
+/** Apply the last setState updater to a mutable fake state and return it. */
+function applyLastUpdater(initial: Record<string, unknown>) {
+  const updater = mockSetState.mock.calls.at(-1)![0] as (s: {
+    config: { baseConfig: Record<string, unknown>; isDirty: boolean };
+  }) => void;
+  const state = { config: { baseConfig: initial, isDirty: false } };
+  updater(state);
+  return state;
+}
+
+describe('MessengerSettings', () => {
+  it('renders the enable toggle, escalation field, and readiness section', () => {
+    render(<MessengerSettings />);
+    expect(screen.getByRole('checkbox', { name: /Enable the Messenger channel/ })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Escalation recipient email/)).toBeInTheDocument();
+    expect(screen.getByText('Readiness')).toBeInTheDocument();
+  });
+
+  it('toggling enable writes the exact key feature_flags.MESSENGER_CHANNEL', async () => {
+    mockBaseConfig = { feature_flags: {} };
+    render(<MessengerSettings />);
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /Enable the Messenger channel/ }));
+
+    const state = applyLastUpdater({ feature_flags: {} as Record<string, boolean> });
+    expect((state.config.baseConfig.feature_flags as Record<string, boolean>).MESSENGER_CHANNEL).toBe(true);
+    expect(state.config.isDirty).toBe(true);
+  });
+
+  it('editing the escalation email writes messenger_behavior.escalation_email (whole-section mutation)', async () => {
+    mockBaseConfig = { messenger_behavior: {} };
+    render(<MessengerSettings />);
+
+    await userEvent.type(screen.getByLabelText(/Escalation recipient email/), 'x');
+
+    const state = applyLastUpdater({ messenger_behavior: {} as Record<string, unknown> });
+    expect((state.config.baseConfig.messenger_behavior as Record<string, unknown>).escalation_email).toBe('x');
+    expect(state.config.isDirty).toBe(true);
+  });
+
+  it('creates messenger_behavior lazily when absent (no crash on a config without the section)', async () => {
+    mockBaseConfig = {}; // no messenger_behavior, no feature_flags
+    render(<MessengerSettings />);
+
+    await userEvent.type(screen.getByLabelText(/Disclosure line/), 'a');
+
+    // Updater must create messenger_behavior.strings on a bare config.
+    const state = applyLastUpdater({});
+    const mb = state.config.baseConfig.messenger_behavior as { strings?: Record<string, string> };
+    expect(mb?.strings?.disclosure_line).toBe('a');
+  });
+
+  it('readiness reflects config-authoritative state (flag off + no recipient = both incomplete)', () => {
+    mockBaseConfig = {};
+    render(<MessengerSettings />);
+    // Neither the enable checkbox nor a recipient is set → the two config-owned
+    // readiness rows read "not done".
+    expect(screen.getByText(/Turn on the Messenger channel above/)).toBeInTheDocument();
+    expect(screen.getByText(/Set an escalation recipient above/)).toBeInTheDocument();
+  });
+
+  it('readiness reflects a fully-configured tenant (flag on + recipient set = both done)', () => {
+    mockBaseConfig = {
+      feature_flags: { MESSENGER_CHANNEL: true },
+      messenger_behavior: { escalation_email: 'staff@example.org' },
+    };
+    render(<MessengerSettings />);
+    expect(screen.getByText(/MESSENGER_CHANNEL is on\./)).toBeInTheDocument();
+    expect(screen.getByText(/Notifications go to staff@example\.org/)).toBeInTheDocument();
+  });
+
+  it('connection readiness reads the S3 channels mirror (display-only, D1-compliant) — not connected when absent', () => {
+    mockBaseConfig = { feature_flags: { MESSENGER_CHANNEL: true } };
+    render(<MessengerSettings />);
+    expect(screen.getByText(/No page connected yet/)).toBeInTheDocument();
+    // Connection is still managed elsewhere — this page never mutates it.
+    expect(screen.getByText(/Connection is managed in the Channels tab/)).toBeInTheDocument();
+  });
+
+  it('connection readiness reflects a connected page from channels.messenger (mirrors ChannelsSettings)', () => {
+    mockBaseConfig = {
+      feature_flags: { MESSENGER_CHANNEL: true },
+      channels: { messenger: { page_id: '1', page_name: 'Acme Page', enabled: true, connected_at: '2026-07-13', connected_by: 'x' } },
+    };
+    render(<MessengerSettings />);
+    expect(screen.getByText(/Connected: Acme Page\. Manage in the Channels tab\./)).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -14,3 +14,4 @@ export { AWSSettings } from './AWSSettings';
 export { FeatureFlagsSettings } from './FeatureFlagsSettings';
 export { NotificationSettings } from './NotificationSettings';
 export { ChannelsSettings } from './ChannelsSettings';
+export { MessengerSettings } from './MessengerSettings';

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,6 +21,7 @@ import {
   FeatureFlagsSettings,
   NotificationSettings,
   ChannelsSettings,
+  MessengerSettings,
 } from '@/components/settings';
 import { EmbedCodeSettings } from '@/components/settings/EmbedCodeSettings';
 
@@ -174,6 +175,7 @@ export const SettingsPage: React.FC = () => {
               <TabsTrigger value="features">Features</TabsTrigger>
               <TabsTrigger value="ai-aws">AI & AWS</TabsTrigger>
               <TabsTrigger value="channels">Channels</TabsTrigger>
+              <TabsTrigger value="messenger">Messenger</TabsTrigger>
             </TabsList>
 
             {/* General Tab */}
@@ -206,6 +208,11 @@ export const SettingsPage: React.FC = () => {
             {/* Channels Tab */}
             <TabsContent value="channels" className="space-y-6 mt-6">
               <ChannelsSettings />
+            </TabsContent>
+
+            {/* Messenger Tab — first "product" grouping (flag + behavior + readiness) */}
+            <TabsContent value="messenger" className="space-y-6 mt-6">
+              <MessengerSettings />
             </TabsContent>
           </Tabs>
 


### PR DESCRIPTION
## What / why
The original **T2c** PR (#87) merged a commit that captured **only the deletion** of the old flat-toggle test — the actual feature files were never committed (a `git add` staging slip). Main wasn't broken (the import wasn't added either), but the Messenger product page was silently absent from `main`. This re-lands the real T2c content:

- `MessengerSettings.tsx` (248 lines) — the product page: enable flag + `escalation_email` + `disclosure_line` + `tone_override` + readiness checklist. Connection row reads the S3 `channels` mirror **display-only** (D1: no gating), as `ChannelsSettings` does.
- `MessengerSettings.test.tsx` (8 tests).
- Settings → **Messenger** tab (`SettingsPage.tsx`), barrel export (`index.ts`).
- `MESSENGER_CHANNEL` removed from the flat `FeatureFlagsSettings` list (graduation rule — one control per flag).

The named pattern-setting **tech-lead review** (APPROVE WITH CHANGES, both fixes applied) is recorded on #87 and still valid — the files here are exactly those reviewed.

## Verification (the check that would have caught the miss)
typecheck clean · full suite **515/515** · **production build succeeds** (the `SettingsPage` → `MessengerSettings` import now resolves) · `git show HEAD` confirms all 5 files in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)