### PR TITLE
feat(settings): Messenger welcome surfaces editor (Messenger Product Surface T3d)

### DIFF
--- a/src/components/settings/MessengerWelcomeSettings.tsx
+++ b/src/components/settings/MessengerWelcomeSettings.tsx
@@ -1,0 +1,302 @@
+/**
+ * MessengerWelcomeSettings — welcome-surfaces editors for the Messenger product
+ * page (Messenger Product Surface T3d).
+ *
+ * Edits `messenger_behavior.welcome` (ice breakers + persistent menu — contract
+ * C2 `MessengerWelcomeConfig`). Mirrors MessengerSettings' whole-object mutation
+ * pattern: `messenger_behavior` (and `.welcome`) are lazily created, the whole
+ * object is mutated, and `isDirty` is set — getMergedConfig emits the complete
+ * section and Config Manager wholesale-replaces it, so no partial patch is ever
+ * sent.
+ *
+ * Honesty note (load-bearing): saving here only updates the tenant config.
+ * Config Builder does NOT push ice breakers / persistent menu to Meta — an
+ * operator must run the M5 re-push script against the live Facebook/Instagram
+ * profile after saving. This mirrors the "mocks are aspirational — keep
+ * truthful state notices" discipline: never imply a live push happens here.
+ */
+
+import React, { useState } from 'react';
+import { Plus, Trash2, AlertCircle, AlertTriangle } from 'lucide-react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  Input,
+  Button,
+  Alert,
+  AlertTitle,
+  AlertDescription,
+} from '@/components/ui';
+import { useConfigStore } from '@/store';
+import type { MessengerWelcomeConfig, MessengerIceBreaker, MessengerMenuItem } from '@/types/config';
+
+const MAX_ICE_BREAKERS = 4;
+
+export const MessengerWelcomeSettings: React.FC = () => {
+  const baseConfig = useConfigStore((state) => state.config.baseConfig);
+
+  const welcome: MessengerWelcomeConfig = baseConfig?.messenger_behavior?.welcome ?? {};
+  const iceBreakers = welcome.ice_breakers ?? [];
+  const menuItems = welcome.persistent_menu ?? [];
+
+  const [newQuestion, setNewQuestion] = useState('');
+  const [newPayload, setNewPayload] = useState('');
+  const [newMenuTitle, setNewMenuTitle] = useState('');
+  const [newMenuPayload, setNewMenuPayload] = useState('');
+  const [newMenuUrl, setNewMenuUrl] = useState('');
+
+  // Mutate messenger_behavior.welcome as a whole (lazily created). getMergedConfig
+  // emits the entire messenger_behavior section; the server wholesale-replaces it.
+  const updateWelcome = (patch: Partial<MessengerWelcomeConfig>) => {
+    useConfigStore.setState((state) => {
+      if (!state.config.baseConfig) return;
+      if (!state.config.baseConfig.messenger_behavior) state.config.baseConfig.messenger_behavior = {};
+      if (!state.config.baseConfig.messenger_behavior.welcome) {
+        state.config.baseConfig.messenger_behavior.welcome = {};
+      }
+      Object.assign(state.config.baseConfig.messenger_behavior.welcome, patch);
+      state.config.isDirty = true;
+    });
+  };
+
+  // --- Ice breakers ---------------------------------------------------------
+
+  const setIceBreakers = (next: MessengerIceBreaker[]) => updateWelcome({ ice_breakers: next });
+
+  const addIceBreaker = () => {
+    if (!newQuestion.trim() || !newPayload.trim()) return;
+    if (iceBreakers.length >= MAX_ICE_BREAKERS) return;
+    setIceBreakers([...iceBreakers, { question: newQuestion.trim(), payload: newPayload.trim() }]);
+    setNewQuestion('');
+    setNewPayload('');
+  };
+
+  const updateIceBreaker = (index: number, patch: Partial<MessengerIceBreaker>) => {
+    setIceBreakers(iceBreakers.map((item, i) => (i === index ? { ...item, ...patch } : item)));
+  };
+
+  const removeIceBreaker = (index: number) => {
+    setIceBreakers(iceBreakers.filter((_, i) => i !== index));
+  };
+
+  // --- Persistent menu --------------------------------------------------------
+
+  const setMenuItems = (next: MessengerMenuItem[]) => updateWelcome({ persistent_menu: next });
+
+  const addMenuItem = () => {
+    if (!newMenuTitle.trim()) return;
+    if (!newMenuPayload.trim() && !newMenuUrl.trim()) return;
+    const item: MessengerMenuItem = { title: newMenuTitle.trim() };
+    if (newMenuPayload.trim()) item.payload = newMenuPayload.trim();
+    if (newMenuUrl.trim()) item.url = newMenuUrl.trim();
+    setMenuItems([...menuItems, item]);
+    setNewMenuTitle('');
+    setNewMenuPayload('');
+    setNewMenuUrl('');
+  };
+
+  const updateMenuItem = (index: number, patch: Partial<MessengerMenuItem>) => {
+    setMenuItems(menuItems.map((item, i) => (i === index ? { ...item, ...patch } : item)));
+  };
+
+  const removeMenuItem = (index: number) => {
+    setMenuItems(menuItems.filter((_, i) => i !== index));
+  };
+
+  const iceBreakersAtCap = iceBreakers.length >= MAX_ICE_BREAKERS;
+
+  return (
+    <div className="space-y-6">
+      {/* Honesty note — CB does not push to Meta */}
+      <Alert variant="warning">
+        <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+        <AlertTitle>Saving here does not update Facebook or Instagram</AlertTitle>
+        <AlertDescription>
+          Config Builder does not push these welcome surfaces to Meta. After saving, an operator
+          must run the M5 re-push script (
+          <code>Meta_OAuth_Handler/scripts/repush_welcome_surfaces.py</code>) to apply ice breakers
+          and the persistent menu to the live Facebook / Instagram profile.
+        </AlertDescription>
+      </Alert>
+
+      {/* Ice breakers */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Ice breakers</CardTitle>
+          <CardDescription>
+            Suggested first questions shown to a visitor before they send a message. Up to{' '}
+            {MAX_ICE_BREAKERS}, per Meta&apos;s platform limit (capability map C5).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {iceBreakers.length > 0 && (
+            <div className="space-y-2 mb-3">
+              {iceBreakers.map((item, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-3 bg-gray-50 dark:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700"
+                >
+                  <div className="flex-1 w-full grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <Input
+                      aria-label={`Ice breaker ${index + 1} question`}
+                      value={item.question}
+                      onChange={(e) => updateIceBreaker(index, { question: e.target.value })}
+                      placeholder="Question shown to the visitor"
+                    />
+                    <Input
+                      aria-label={`Ice breaker ${index + 1} payload`}
+                      value={item.payload}
+                      onChange={(e) => updateIceBreaker(index, { payload: e.target.value })}
+                      placeholder="C3 payload namespace, e.g. PIC1:…"
+                    />
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeIceBreaker(index)}
+                    className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950 flex-shrink-0"
+                    aria-label={`Remove ice breaker ${index + 1}`}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <Input
+                label="Question"
+                value={newQuestion}
+                onChange={(e) => setNewQuestion(e.target.value)}
+                placeholder="e.g., How do I volunteer?"
+                disabled={iceBreakersAtCap}
+              />
+              <Input
+                label="Payload"
+                value={newPayload}
+                onChange={(e) => setNewPayload(e.target.value)}
+                placeholder="e.g., PIC1:VOLUNTEER_INFO"
+                helperText="C3 payload namespace, e.g. PIC1:…"
+                disabled={iceBreakersAtCap}
+              />
+            </div>
+            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                {iceBreakers.length} / {MAX_ICE_BREAKERS} ice breakers
+              </span>
+              <Button
+                onClick={addIceBreaker}
+                disabled={!newQuestion.trim() || !newPayload.trim() || iceBreakersAtCap}
+                size="sm"
+                className="w-full sm:w-auto"
+              >
+                <Plus className="w-4 h-4 mr-1" />
+                Add ice breaker
+              </Button>
+            </div>
+          </div>
+
+          {iceBreakersAtCap && (
+            <div className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400 mt-2">
+              <AlertCircle className="w-4 h-4" />
+              Maximum of {MAX_ICE_BREAKERS} ice breakers reached (Meta platform limit).
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Persistent menu */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Persistent menu</CardTitle>
+          <CardDescription>
+            Always-visible menu options in the Messenger conversation. Each item needs either a
+            payload (handled by the bot) or a URL (opens externally).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {menuItems.length > 0 && (
+            <div className="space-y-2 mb-3">
+              {menuItems.map((item, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-3 bg-gray-50 dark:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700"
+                >
+                  <div className="flex-1 w-full grid grid-cols-1 sm:grid-cols-3 gap-2">
+                    <Input
+                      aria-label={`Menu item ${index + 1} title`}
+                      value={item.title}
+                      onChange={(e) => updateMenuItem(index, { title: e.target.value })}
+                      placeholder="Menu label"
+                    />
+                    <Input
+                      aria-label={`Menu item ${index + 1} payload`}
+                      value={item.payload ?? ''}
+                      onChange={(e) => updateMenuItem(index, { payload: e.target.value || undefined })}
+                      placeholder="Payload (bot-handled)"
+                    />
+                    <Input
+                      aria-label={`Menu item ${index + 1} url`}
+                      value={item.url ?? ''}
+                      onChange={(e) => updateMenuItem(index, { url: e.target.value || undefined })}
+                      placeholder="URL (opens externally)"
+                    />
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeMenuItem(index)}
+                    className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950 flex-shrink-0"
+                    aria-label={`Remove menu item ${index + 1}`}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              <Input
+                label="Title"
+                value={newMenuTitle}
+                onChange={(e) => setNewMenuTitle(e.target.value)}
+                placeholder="e.g., Our programs"
+              />
+              <Input
+                label="Payload (optional)"
+                value={newMenuPayload}
+                onChange={(e) => setNewMenuPayload(e.target.value)}
+                placeholder="e.g., PIC1:PROGRAMS"
+                helperText="Use payload OR url"
+              />
+              <Input
+                label="URL (optional)"
+                value={newMenuUrl}
+                onChange={(e) => setNewMenuUrl(e.target.value)}
+                placeholder="https://…"
+              />
+            </div>
+            <div className="flex flex-col sm:flex-row sm:justify-end gap-2">
+              <Button
+                onClick={addMenuItem}
+                disabled={!newMenuTitle.trim() || (!newMenuPayload.trim() && !newMenuUrl.trim())}
+                size="sm"
+                className="w-full sm:w-auto"
+              >
+                <Plus className="w-4 h-4 mr-1" />
+                Add menu item
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/settings/__tests__/MessengerWelcomeSettings.test.tsx
+++ b/src/components/settings/__tests__/MessengerWelcomeSettings.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * MessengerWelcomeSettings — welcome-surfaces editors (Messenger Product Surface
+ * T3d). Load-bearing assertions: adding writes the EXACT keys
+ * messenger_behavior.welcome.ice_breakers / .persistent_menu; the ice-breaker
+ * ≤4 cap (capability map C5) disables Add at 4; the M5 re-push honesty notice
+ * is present (Config Builder does NOT push to Meta); messenger_behavior /
+ * welcome are lazily created on a bare config (no crash).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+let mockBaseConfig: Record<string, unknown> | null = {};
+const mockSetState = vi.fn();
+
+vi.mock('@/store', () => ({
+  useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ config: { baseConfig: mockBaseConfig, isDirty: false } })
+  ),
+}));
+
+import { useConfigStore } from '@/store';
+import { MessengerWelcomeSettings } from '../MessengerWelcomeSettings';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBaseConfig = {};
+  (useConfigStore as unknown as { setState: typeof mockSetState }).setState = mockSetState;
+});
+
+/** Apply the last setState updater to a mutable fake state and return it. */
+function applyLastUpdater(initial: Record<string, unknown>) {
+  const updater = mockSetState.mock.calls.at(-1)![0] as (s: {
+    config: { baseConfig: Record<string, unknown>; isDirty: boolean };
+  }) => void;
+  const state = { config: { baseConfig: initial, isDirty: false } };
+  updater(state);
+  return state;
+}
+
+describe('MessengerWelcomeSettings', () => {
+  it('renders the ice breakers and persistent menu editors', () => {
+    render(<MessengerWelcomeSettings />);
+    expect(screen.getByText('Ice breakers')).toBeInTheDocument();
+    expect(screen.getByText('Persistent menu')).toBeInTheDocument();
+  });
+
+  it('shows the M5 re-push honesty notice (CB does not push to Meta)', () => {
+    render(<MessengerWelcomeSettings />);
+    expect(
+      screen.getByText(/Config Builder does not push these welcome surfaces to Meta/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/repush_welcome_surfaces\.py/)).toBeInTheDocument();
+  });
+
+  it('adding an ice breaker writes messenger_behavior.welcome.ice_breakers', async () => {
+    mockBaseConfig = { messenger_behavior: { welcome: {} } };
+    render(<MessengerWelcomeSettings />);
+
+    await userEvent.type(screen.getByLabelText('Question'), 'How do I volunteer?');
+    await userEvent.type(screen.getByLabelText('Payload'), 'PIC1:VOLUNTEER_INFO');
+    await userEvent.click(screen.getByRole('button', { name: /Add ice breaker/ }));
+
+    const state = applyLastUpdater({ messenger_behavior: { welcome: {} } });
+    const welcome = (state.config.baseConfig.messenger_behavior as Record<string, unknown>).welcome as {
+      ice_breakers?: Array<{ question: string; payload: string }>;
+    };
+    expect(welcome.ice_breakers).toEqual([
+      { question: 'How do I volunteer?', payload: 'PIC1:VOLUNTEER_INFO' },
+    ]);
+    expect(state.config.isDirty).toBe(true);
+  });
+
+  it('disables Add at the 4-item ice-breaker cap (capability map C5)', () => {
+    mockBaseConfig = {
+      messenger_behavior: {
+        welcome: {
+          ice_breakers: [
+            { question: 'Q1', payload: 'PIC1:A' },
+            { question: 'Q2', payload: 'PIC1:B' },
+            { question: 'Q3', payload: 'PIC1:C' },
+            { question: 'Q4', payload: 'PIC1:D' },
+          ],
+        },
+      },
+    };
+    render(<MessengerWelcomeSettings />);
+
+    expect(screen.getByRole('button', { name: /Add ice breaker/ })).toBeDisabled();
+    expect(screen.getByText(/Maximum of 4 ice breakers reached/)).toBeInTheDocument();
+    expect(screen.getByText('4 / 4 ice breakers')).toBeInTheDocument();
+  });
+
+  it('removing an ice breaker updates the array', async () => {
+    mockBaseConfig = {
+      messenger_behavior: { welcome: { ice_breakers: [{ question: 'Q1', payload: 'PIC1:A' }] } },
+    };
+    render(<MessengerWelcomeSettings />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove ice breaker 1' }));
+
+    const state = applyLastUpdater({
+      messenger_behavior: { welcome: { ice_breakers: [{ question: 'Q1', payload: 'PIC1:A' }] } },
+    });
+    const welcome = (state.config.baseConfig.messenger_behavior as Record<string, unknown>).welcome as {
+      ice_breakers?: unknown[];
+    };
+    expect(welcome.ice_breakers).toEqual([]);
+  });
+
+  it('adding a persistent menu item writes messenger_behavior.welcome.persistent_menu', async () => {
+    mockBaseConfig = { messenger_behavior: { welcome: {} } };
+    render(<MessengerWelcomeSettings />);
+
+    await userEvent.type(screen.getByLabelText('Title'), 'Our programs');
+    await userEvent.type(screen.getByLabelText('Payload (optional)'), 'PIC1:PROGRAMS');
+    await userEvent.click(screen.getByRole('button', { name: /Add menu item/ }));
+
+    const state = applyLastUpdater({ messenger_behavior: { welcome: {} } });
+    const welcome = (state.config.baseConfig.messenger_behavior as Record<string, unknown>).welcome as {
+      persistent_menu?: Array<{ title: string; payload?: string }>;
+    };
+    expect(welcome.persistent_menu).toEqual([{ title: 'Our programs', payload: 'PIC1:PROGRAMS' }]);
+    expect(state.config.isDirty).toBe(true);
+  });
+
+  it('creates messenger_behavior.welcome lazily on a bare config (no crash)', async () => {
+    mockBaseConfig = {}; // no messenger_behavior, no welcome
+    render(<MessengerWelcomeSettings />);
+
+    await userEvent.type(screen.getByLabelText('Question'), 'Q');
+    await userEvent.type(screen.getByLabelText('Payload'), 'PIC1:X');
+    await userEvent.click(screen.getByRole('button', { name: /Add ice breaker/ }));
+
+    const state = applyLastUpdater({});
+    const mb = state.config.baseConfig.messenger_behavior as { welcome?: { ice_breakers?: unknown[] } };
+    expect(mb?.welcome?.ice_breakers).toEqual([{ question: 'Q', payload: 'PIC1:X' }]);
+  });
+});

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -15,3 +15,4 @@ export { FeatureFlagsSettings } from './FeatureFlagsSettings';
 export { NotificationSettings } from './NotificationSettings';
 export { ChannelsSettings } from './ChannelsSettings';
 export { MessengerSettings } from './MessengerSettings';
+export { MessengerWelcomeSettings } from './MessengerWelcomeSettings';

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -22,6 +22,7 @@ import {
   NotificationSettings,
   ChannelsSettings,
   MessengerSettings,
+  MessengerWelcomeSettings,
 } from '@/components/settings';
 import { EmbedCodeSettings } from '@/components/settings/EmbedCodeSettings';
 
@@ -213,6 +214,7 @@ export const SettingsPage: React.FC = () => {
             {/* Messenger Tab — first "product" grouping (flag + behavior + readiness) */}
             <TabsContent value="messenger" className="space-y-6 mt-6">
               <MessengerSettings />
+              <MessengerWelcomeSettings />
             </TabsContent>
           </Tabs>
 


### PR DESCRIPTION
## Summary

Adds welcome-surfaces editors (ice breakers + persistent menu) to the Messenger product page, subphase T3d of the Messenger Product Surface program.

- New `MessengerWelcomeSettings` component: an ice-breakers editor (`{question, payload}`, add/edit/remove) and a persistent-menu editor (`{title, payload?, url?}`, add/edit/remove).
- **Enforces the ≤4 ice-breaker cap client-side** (capability map C5) — the "Add" button disables at 4 items with a visible note.
- Reads/writes `baseConfig.messenger_behavior.welcome` via `useConfigStore.setState`, mirroring `MessengerSettings`' whole-object mutation pattern exactly: `messenger_behavior` and `.welcome` are lazily created, the whole object is mutated, `isDirty` is set. `getMergedConfig` emits the complete section so the server wholesale-replaces it — no partial patch.
- **Honesty note (load-bearing):** a visible warning that Config Builder does **not** push these to Meta — an operator must run the M5 re-push script (`Meta_OAuth_Handler/scripts/repush_welcome_surfaces.py`) against the live Facebook/Instagram profile after saving. No live push is implied.
- Wired into `SettingsPage.tsx`'s existing `value="messenger"` tab, rendered after `MessengerSettings`, and exported from the settings barrel.

## Why

Continues the Messenger Product Surface program's T2c pattern (product page = enable toggle + config fields + readiness/honesty notes) into welcome surfaces, per the approved plan. This is UI-only — no Lambda/backend changes.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 524/524 tests passed across 49 files (7 new tests in `MessengerWelcomeSettings.test.tsx`: renders both editors, honesty notice present, ice-breaker add writes `messenger_behavior.welcome.ice_breakers`, ≤4 cap disables Add, remove works, persistent-menu add writes `messenger_behavior.welcome.persistent_menu`, lazy-init on a bare config with no `messenger_behavior`/`welcome`)
- [x] `npx eslint` on changed files — clean
- [x] `npm run build:production` — succeeded (`dist/main.js` 959.2kb), confirms the `SettingsPage.tsx` import resolves

No live/browser verification was performed — verification is limited to typecheck/test/lint/build as above.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>