### PR TITLE
feat(deploy): auto-push Messenger welcome surfaces to Meta on deploy

### DIFF
--- a/src/components/settings/MessengerWelcomeSettings.tsx
+++ b/src/components/settings/MessengerWelcomeSettings.tsx
@@ -9,15 +9,16 @@
  * section and Config Manager wholesale-replaces it, so no partial patch is ever
  * sent.
  *
- * Honesty note (load-bearing): saving here only updates the tenant config.
- * Config Builder does NOT push ice breakers / persistent menu to Meta — an
- * operator must run the M5 re-push script against the live Facebook/Instagram
- * profile after saving. This mirrors the "mocks are aspirational — keep
- * truthful state notices" discipline: never imply a live push happens here.
+ * Push behavior (truthful-state note): editing here only updates the tenant
+ * config. The live Facebook/Instagram profile is updated on DEPLOY — the deploy
+ * flow auto-calls Meta_OAuth_Handler's repush-welcome endpoint when welcome
+ * surfaces are configured and a page is connected (see store/slices/config.ts +
+ * lib/api/metaWelcome.ts). The in-card notice states this; the manual fallback
+ * is scripts/repush_welcome_surfaces.py. Never imply an edit alone pushes.
  */
 
 import React, { useState } from 'react';
-import { Plus, Trash2, AlertCircle, AlertTriangle } from 'lucide-react';
+import { Plus, Trash2, AlertCircle, Info } from 'lucide-react';
 import {
   Card,
   CardHeader,
@@ -110,15 +111,16 @@ export const MessengerWelcomeSettings: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      {/* Honesty note — CB does not push to Meta */}
-      <Alert variant="warning">
-        <AlertTriangle className="h-4 w-4" aria-hidden="true" />
-        <AlertTitle>Saving here does not update Facebook or Instagram</AlertTitle>
+      {/* How-it-works note — welcome surfaces auto-push to Meta on Deploy */}
+      <Alert variant="info">
+        <Info className="h-4 w-4" aria-hidden="true" />
+        <AlertTitle>These push to Facebook &amp; Instagram when you Deploy</AlertTitle>
         <AlertDescription>
-          Config Builder does not push these welcome surfaces to Meta. After saving, an operator
-          must run the M5 re-push script (
-          <code>Meta_OAuth_Handler/scripts/repush_welcome_surfaces.py</code>) to apply ice breakers
-          and the persistent menu to the live Facebook / Instagram profile.
+          When you <strong>Deploy</strong>, Config Builder pushes these ice breakers and the
+          persistent menu to the live Facebook / Instagram profile automatically — as long as the
+          page is connected (see the Channels tab). Editing here without deploying does not update
+          Meta, and nothing is pushed until a page is connected. (The manual fallback is still{' '}
+          <code>Meta_OAuth_Handler/scripts/repush_welcome_surfaces.py</code>.)
         </AlertDescription>
       </Alert>
 

--- a/src/components/settings/__tests__/MessengerWelcomeSettings.test.tsx
+++ b/src/components/settings/__tests__/MessengerWelcomeSettings.test.tsx
@@ -46,11 +46,13 @@ describe('MessengerWelcomeSettings', () => {
     expect(screen.getByText('Persistent menu')).toBeInTheDocument();
   });
 
-  it('shows the M5 re-push honesty notice (CB does not push to Meta)', () => {
+  it('shows the truthful-state notice (surfaces push to Meta on Deploy; edits alone do not)', () => {
     render(<MessengerWelcomeSettings />);
-    expect(
-      screen.getByText(/Config Builder does not push these welcome surfaces to Meta/)
-    ).toBeInTheDocument();
+    // Title states the push happens on Deploy.
+    expect(screen.getByText(/push to Facebook & Instagram when you Deploy/)).toBeInTheDocument();
+    // Body is truthful that editing alone does not update Meta.
+    expect(screen.getByText(/Editing here without deploying does not update/)).toBeInTheDocument();
+    // Manual fallback still referenced.
     expect(screen.getByText(/repush_welcome_surfaces\.py/)).toBeInTheDocument();
   });
 

--- a/src/lib/api/__tests__/metaWelcome.test.ts
+++ b/src/lib/api/__tests__/metaWelcome.test.ts
@@ -1,0 +1,122 @@
+/**
+ * metaWelcome — auto-push welcome surfaces after deploy.
+ *
+ * VITE_CHANNELS_API_URL is stubbed to a test URL in src/test/setup.ts, so the
+ * module-level const resolves configured here (the not-configured branch is
+ * covered separately via resetModules + stubEnv('')).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { TenantConfig } from '@/types/config';
+import { shouldRepushWelcome, repushWelcomeSurfaces } from '../metaWelcome';
+
+const connectedMessenger = {
+  page_id: '1',
+  page_name: 'Acme',
+  enabled: true,
+  connected_at: '2026-07-13',
+  connected_by: 'x',
+};
+
+function cfg(overrides: Record<string, unknown>): TenantConfig {
+  return overrides as unknown as TenantConfig;
+}
+
+describe('shouldRepushWelcome', () => {
+  it('true only when welcome surfaces exist AND a messenger page is connected', () => {
+    expect(
+      shouldRepushWelcome(
+        cfg({
+          channels: { messenger: connectedMessenger },
+          messenger_behavior: { welcome: { ice_breakers: [{ question: 'q', payload: 'PIC1:x' }] } },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('false when surfaces exist but no page connected', () => {
+    expect(
+      shouldRepushWelcome(
+        cfg({ messenger_behavior: { welcome: { ice_breakers: [{ question: 'q', payload: 'p' }] } } })
+      )
+    ).toBe(false);
+  });
+
+  it('false when connected but no welcome surfaces', () => {
+    expect(shouldRepushWelcome(cfg({ channels: { messenger: connectedMessenger } }))).toBe(false);
+    expect(
+      shouldRepushWelcome(
+        cfg({ channels: { messenger: connectedMessenger }, messenger_behavior: { welcome: {} } })
+      )
+    ).toBe(false);
+  });
+
+  it('true via persistent_menu alone', () => {
+    expect(
+      shouldRepushWelcome(
+        cfg({
+          channels: { messenger: connectedMessenger },
+          messenger_behavior: { welcome: { persistent_menu: [{ title: 'Home', url: 'https://x' }] } },
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe('repushWelcomeSurfaces', () => {
+  const mockFetch = vi.fn();
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('classifies a pushed result and calls the repush endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { pushed: { ice_breakers: 3, persistent_menu: 2 } } }),
+    });
+    const outcome = await repushWelcomeSurfaces('TENANT_1');
+    expect(outcome).toEqual({ status: 'pushed', detail: '3 ice breakers, 2 menu items' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/meta/channels/TENANT_1/repush-welcome'),
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('passes through a best-effort skip (flag off / nothing to push)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { skipped: 'MESSENGER_CHANNEL flag not enabled' } }),
+    });
+    expect(await repushWelcomeSurfaces('T')).toEqual({
+      status: 'skipped',
+      detail: 'MESSENGER_CHANNEL flag not enabled',
+    });
+  });
+
+  it('returns failed on a non-2xx (never throws)', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({ error: 'No messenger channel connected for this tenant' }) });
+    expect(await repushWelcomeSurfaces('T')).toEqual({
+      status: 'failed',
+      detail: 'No messenger channel connected for this tenant',
+    });
+  });
+
+  it('returns failed on a network error (never throws)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+    expect(await repushWelcomeSurfaces('T')).toEqual({ status: 'failed', detail: 'network down' });
+  });
+});
+
+describe('repushWelcomeSurfaces — not configured', () => {
+  it('returns not-configured and does NOT fetch when VITE_CHANNELS_API_URL is unset', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_CHANNELS_API_URL', '');
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+    const { repushWelcomeSurfaces: fn } = await import('../metaWelcome');
+    expect(await fn('T')).toEqual({ status: 'not-configured' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/lib/api/metaWelcome.ts
+++ b/src/lib/api/metaWelcome.ts
@@ -1,0 +1,69 @@
+/**
+ * metaWelcome — auto-push Messenger welcome surfaces to Meta after a deploy.
+ *
+ * Config Builder edits `messenger_behavior.welcome` (ice breakers + persistent
+ * menu), but those only reach the live Facebook/Instagram profile via the
+ * Messenger Profile API. Rather than make an operator run the M5 re-push script
+ * by hand, the deploy flow calls `POST /meta/channels/{id}/repush-welcome` on
+ * Meta_OAuth_Handler (which re-pushes using the stored Page token — the same
+ * code path the OAuth callback uses).
+ *
+ * Best-effort: the deploy itself is the primary action and has already
+ * succeeded by the time this runs — a push failure only warns, never throws.
+ *
+ * The endpoint is unauthenticated today (CORS *, no Clerk), so no token is
+ * sent. If it is ever put behind auth, thread the Clerk token through here.
+ */
+import type { TenantConfig } from '@/types/config';
+
+const CHANNELS_API_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_CHANNELS_API_URL) || '';
+
+/** True when the config has welcome surfaces AND a connected Messenger page worth pushing to. */
+export function shouldRepushWelcome(config: TenantConfig): boolean {
+  const welcome = config.messenger_behavior?.welcome;
+  const hasSurfaces = Boolean(welcome?.ice_breakers?.length || welcome?.persistent_menu?.length);
+  const connected = Boolean(config.channels?.messenger);
+  return hasSurfaces && connected;
+}
+
+export type RepushOutcome =
+  | { status: 'pushed'; detail: string }
+  | { status: 'skipped'; detail: string }
+  | { status: 'failed'; detail: string }
+  | { status: 'not-configured' };
+
+/**
+ * Re-push welcome surfaces for a tenant. Never throws — returns a classified outcome:
+ * - `pushed`  — Meta accepted the surfaces
+ * - `skipped` — nothing to push (flag off / no surfaces), per the endpoint's best-effort result
+ * - `failed`  — the call errored (network, 4xx/5xx); the caller should warn, not block
+ * - `not-configured` — VITE_CHANNELS_API_URL is unset for this build (no auto-push wired)
+ */
+export async function repushWelcomeSurfaces(tenantId: string): Promise<RepushOutcome> {
+  if (!CHANNELS_API_URL) return { status: 'not-configured' };
+  try {
+    const res = await fetch(
+      `${CHANNELS_API_URL}/meta/channels/${encodeURIComponent(tenantId)}/repush-welcome`,
+      { method: 'POST' }
+    );
+    const body = (await res.json().catch(() => ({}))) as {
+      error?: string;
+      result?: { pushed?: { ice_breakers?: number; persistent_menu?: number }; skipped?: string };
+    };
+    if (!res.ok) return { status: 'failed', detail: body?.error || `HTTP ${res.status}` };
+
+    const result = body?.result ?? {};
+    if (result.pushed) {
+      const p = result.pushed;
+      return {
+        status: 'pushed',
+        detail: `${p.ice_breakers ?? 0} ice breakers, ${p.persistent_menu ?? 0} menu items`,
+      };
+    }
+    if (result.skipped) return { status: 'skipped', detail: String(result.skipped) };
+    return { status: 'skipped', detail: 'no changes to push' };
+  } catch (e) {
+    return { status: 'failed', detail: e instanceof Error ? e.message : 'network error' };
+  }
+}

--- a/src/store/slices/config.ts
+++ b/src/store/slices/config.ts
@@ -7,6 +7,7 @@ import type { TenantConfig, ConversationalForm, ConversationBranch } from '@/typ
 import type { SliceCreator, ConfigSlice } from '../types';
 import * as configAPI from '@/lib/api/config-operations';
 import { ConfigAPIError } from '@/lib/api/errors';
+import { shouldRepushWelcome, repushWelcomeSurfaces } from '@/lib/api/metaWelcome';
 
 /**
  * Schema discipline: stored configs may carry old-shape branches (no `secondary`
@@ -234,6 +235,26 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
         type: 'success',
         message: 'Configuration deployed successfully',
       });
+
+      // Auto-push Messenger welcome surfaces (ice breakers + persistent menu) to
+      // the live Meta profile when they're configured and a page is connected —
+      // so an operator never has to run the M5 re-push script by hand. Best-effort:
+      // the deploy already succeeded, so a push failure only warns.
+      if (shouldRepushWelcome(mergedConfig)) {
+        const outcome = await repushWelcomeSurfaces(state.config.tenantId);
+        if (outcome.status === 'pushed') {
+          state.ui.addToast({
+            type: 'success',
+            message: `Welcome surfaces pushed to Facebook / Instagram (${outcome.detail}).`,
+          });
+        } else if (outcome.status === 'failed') {
+          state.ui.addToast({
+            type: 'warning',
+            message: `Deployed, but pushing welcome surfaces to Meta failed: ${outcome.detail}. Re-deploy to retry.`,
+          });
+        }
+        // 'skipped' (flag off / nothing to push) and 'not-configured' are silent.
+      }
     } catch (error) {
       // Mirror saveConfig: an ETag mismatch renders the reload banner
       // instead of the generic error toast.


### PR DESCRIPTION
## What
Config Builder now pushes `messenger_behavior.welcome` (ice breakers + persistent menu) to the **live Facebook/Instagram profile automatically when you Deploy** — closing the "run the M5 script by hand" gap you flagged.

Pairs with **lambda#460** (the `POST /meta/channels/{id}/repush-welcome` endpoint).

## How
After a successful deploy, if the config has welcome surfaces **and** a connected Messenger page (`shouldRepushWelcome`), the deploy flow calls the repush endpoint. **Best-effort** — the deploy already succeeded, so a push failure only warns:
- ✅ pushed → toast with counts
- ⚠️ failed → "Deployed, but pushing welcome surfaces to Meta failed: … Re-deploy to retry"
- silent → flag off / nothing to push / `VITE_CHANNELS_API_URL` unset

New `src/lib/api/metaWelcome.ts` (gate + never-throws `repushWelcomeSurfaces`). The in-card notice + docstring now say the push happens on Deploy (editing alone still doesn't update Meta; connect a page first).

## Notes
- The endpoint is unauthenticated today (no Clerk), so no token is sent — noted in the helper for if that changes (it inherits the pre-existing `/meta/channels/*` authz gap).
- **Ordering:** merge lambda#460 first so the endpoint is live; if CB deploys before it's up, the push just warns and the operator re-deploys.

## Verification
9 `metaWelcome` tests (gate logic + pushed/skip/fail/network/not-configured) + welcome-settings tests + full suite **533/533** · typecheck + eslint clean · prod build ok. Live deploy→push round-trip is operator-verified (needs a Clerk-authed deploy + connected staging page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)