### PR TITLE
feat(messenger): welcome-surface payloads → live CTA dropdown

### DIFF
--- a/src/components/settings/MessengerWelcomeSettings.tsx
+++ b/src/components/settings/MessengerWelcomeSettings.tsx
@@ -26,22 +26,49 @@ import {
   CardDescription,
   CardContent,
   Input,
+  Select,
   Button,
   Alert,
   AlertTitle,
   AlertDescription,
 } from '@/components/ui';
+import type { SelectOption } from '@/components/ui';
 import { useConfigStore } from '@/store';
 import type { MessengerWelcomeConfig, MessengerIceBreaker, MessengerMenuItem } from '@/types/config';
 
 const MAX_ICE_BREAKERS = 4;
+// Sentinel for "no CTA" in the optional persistent-menu payload select
+// (Radix Select items can't use an empty-string value).
+const NO_CTA = '__none__';
 
 export const MessengerWelcomeSettings: React.FC = () => {
   const baseConfig = useConfigStore((state) => state.config.baseConfig);
+  // CTAs are the payload vocabulary for welcome surfaces: a tap resolves
+  // PIC1:cta:{id} against cta_definitions. Read them live from the store so the
+  // dropdown reflects CTAs as they're added/removed elsewhere in the builder.
+  const ctas = useConfigStore((state) => state.ctas.ctas);
 
   const welcome: MessengerWelcomeConfig = baseConfig?.messenger_behavior?.welcome ?? {};
   const iceBreakers = welcome.ice_breakers ?? [];
   const menuItems = welcome.persistent_menu ?? [];
+
+  // Live CTA options, value = the exact payload the Messenger processor resolves.
+  const ctaOptions: SelectOption[] = Object.entries(ctas ?? {}).map(([id, cta]) => ({
+    value: `PIC1:cta:${id}`,
+    label: `${(cta.label ?? '').trim() || id} — ${id}`,
+  }));
+  const hasCtas = ctaOptions.length > 0;
+  // Keep a saved payload that no longer matches a CTA (e.g. the CTA was deleted,
+  // or a legacy raw payload) visible instead of silently blanking it.
+  const withCurrent = (current: string | undefined): SelectOption[] =>
+    current && !ctaOptions.some((o) => o.value === current)
+      ? [...ctaOptions, { value: current, label: `${current} — not a current CTA` }]
+      : ctaOptions;
+  // Optional payload (persistent menu): prepend a "no CTA" choice.
+  const menuPayloadOptions = (current: string | undefined): SelectOption[] => [
+    { value: NO_CTA, label: '— No CTA (use a URL) —' },
+    ...withCurrent(current),
+  ];
 
   const [newQuestion, setNewQuestion] = useState('');
   const [newPayload, setNewPayload] = useState('');
@@ -129,11 +156,18 @@ export const MessengerWelcomeSettings: React.FC = () => {
         <CardHeader>
           <CardTitle>Ice breakers</CardTitle>
           <CardDescription>
-            Suggested first questions shown to a visitor before they send a message. Up to{' '}
-            {MAX_ICE_BREAKERS}, per Meta&apos;s platform limit (capability map C5).
+            Suggested first questions shown to a visitor before they send a message. Each links to a
+            CTA, which fires when the visitor taps it. Up to {MAX_ICE_BREAKERS}, per Meta&apos;s
+            platform limit (capability map C5).
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {!hasCtas && (
+            <div className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400 mb-3">
+              <AlertCircle className="w-4 h-4" />
+              No CTAs defined yet — create CTAs in the CTAs tab, then link them here.
+            </div>
+          )}
           {iceBreakers.length > 0 && (
             <div className="space-y-2 mb-3">
               {iceBreakers.map((item, index) => (
@@ -148,11 +182,12 @@ export const MessengerWelcomeSettings: React.FC = () => {
                       onChange={(e) => updateIceBreaker(index, { question: e.target.value })}
                       placeholder="Question shown to the visitor"
                     />
-                    <Input
-                      aria-label={`Ice breaker ${index + 1} payload`}
+                    <Select
+                      placeholder={hasCtas ? 'Link a CTA…' : 'No CTAs defined'}
+                      options={withCurrent(item.payload)}
                       value={item.payload}
-                      onChange={(e) => updateIceBreaker(index, { payload: e.target.value })}
-                      placeholder="C3 payload namespace, e.g. PIC1:…"
+                      onValueChange={(v) => updateIceBreaker(index, { payload: v })}
+                      disabled={!hasCtas && !item.payload}
                     />
                   </div>
                   <Button
@@ -178,13 +213,14 @@ export const MessengerWelcomeSettings: React.FC = () => {
                 placeholder="e.g., How do I volunteer?"
                 disabled={iceBreakersAtCap}
               />
-              <Input
-                label="Payload"
+              <Select
+                label="Linked CTA"
+                placeholder={hasCtas ? 'Choose a CTA…' : 'No CTAs defined'}
+                options={ctaOptions}
                 value={newPayload}
-                onChange={(e) => setNewPayload(e.target.value)}
-                placeholder="e.g., PIC1:VOLUNTEER_INFO"
-                helperText="C3 payload namespace, e.g. PIC1:…"
-                disabled={iceBreakersAtCap}
+                onValueChange={setNewPayload}
+                helperText="Tapping the ice breaker fires this CTA. Options come from your CTA definitions."
+                disabled={iceBreakersAtCap || !hasCtas}
               />
             </div>
             <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
@@ -217,8 +253,8 @@ export const MessengerWelcomeSettings: React.FC = () => {
         <CardHeader>
           <CardTitle>Persistent menu</CardTitle>
           <CardDescription>
-            Always-visible menu options in the Messenger conversation. Each item needs either a
-            payload (handled by the bot) or a URL (opens externally).
+            Always-visible menu options in the Messenger conversation. Each item links to either a
+            CTA (handled by the bot) or a URL (opens externally).
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -236,11 +272,13 @@ export const MessengerWelcomeSettings: React.FC = () => {
                       onChange={(e) => updateMenuItem(index, { title: e.target.value })}
                       placeholder="Menu label"
                     />
-                    <Input
-                      aria-label={`Menu item ${index + 1} payload`}
-                      value={item.payload ?? ''}
-                      onChange={(e) => updateMenuItem(index, { payload: e.target.value || undefined })}
-                      placeholder="Payload (bot-handled)"
+                    <Select
+                      placeholder="Link a CTA…"
+                      options={menuPayloadOptions(item.payload)}
+                      value={item.payload ?? NO_CTA}
+                      onValueChange={(v) =>
+                        updateMenuItem(index, { payload: v === NO_CTA ? undefined : v })
+                      }
                     />
                     <Input
                       aria-label={`Menu item ${index + 1} url`}
@@ -271,12 +309,13 @@ export const MessengerWelcomeSettings: React.FC = () => {
                 onChange={(e) => setNewMenuTitle(e.target.value)}
                 placeholder="e.g., Our programs"
               />
-              <Input
-                label="Payload (optional)"
-                value={newMenuPayload}
-                onChange={(e) => setNewMenuPayload(e.target.value)}
-                placeholder="e.g., PIC1:PROGRAMS"
-                helperText="Use payload OR url"
+              <Select
+                label="Linked CTA (optional)"
+                placeholder="Choose a CTA…"
+                options={menuPayloadOptions(newMenuPayload || undefined)}
+                value={newMenuPayload || NO_CTA}
+                onValueChange={(v) => setNewMenuPayload(v === NO_CTA ? '' : v)}
+                helperText="Use a CTA OR a URL"
               />
               <Input
                 label="URL (optional)"

--- a/src/components/settings/__tests__/MessengerWelcomeSettings.test.tsx
+++ b/src/components/settings/__tests__/MessengerWelcomeSettings.test.tsx
@@ -1,10 +1,15 @@
 /**
  * MessengerWelcomeSettings — welcome-surfaces editors (Messenger Product Surface
- * T3d). Load-bearing assertions: adding writes the EXACT keys
- * messenger_behavior.welcome.ice_breakers / .persistent_menu; the ice-breaker
- * ≤4 cap (capability map C5) disables Add at 4; the M5 re-push honesty notice
- * is present (Config Builder does NOT push to Meta); messenger_behavior /
- * welcome are lazily created on a bare config (no crash).
+ * T3d + the dynamic CTA-dropdown follow-up). Load-bearing assertions: the payload
+ * fields are CTA dropdowns whose options come LIVE from cta_definitions and whose
+ * value is the exact `PIC1:cta:{id}` the Messenger processor resolves; adding
+ * writes messenger_behavior.welcome.ice_breakers / .persistent_menu; the ≤4 cap
+ * disables Add; the deploy-push notice is present; a stale payload is preserved.
+ *
+ * The `@/components/ui` Select is Radix-backed and awkward to drive in jsdom, so
+ * it is mocked to a native <select> here — the value/onValueChange/options
+ * contract is identical, and the mapping (value === PIC1:cta:{id}) is what we
+ * actually care about.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -12,13 +17,53 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 let mockBaseConfig: Record<string, unknown> | null = {};
+let mockCtas: Record<string, { label?: string; action?: string }> = {};
 const mockSetState = vi.fn();
 
 vi.mock('@/store', () => ({
   useConfigStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ config: { baseConfig: mockBaseConfig, isDirty: false } })
+    selector({ config: { baseConfig: mockBaseConfig, isDirty: false }, ctas: { ctas: mockCtas } })
   ),
 }));
+
+// Native-<select> stand-in for the Radix Select (same value/onValueChange/options API).
+vi.mock('@/components/ui', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    Select: ({
+      label,
+      placeholder,
+      options,
+      value,
+      onValueChange,
+      disabled,
+    }: {
+      label?: string;
+      placeholder?: string;
+      options: Array<{ value: string; label: string }>;
+      value?: string;
+      onValueChange?: (v: string) => void;
+      disabled?: boolean;
+    }) => (
+      <select
+        aria-label={label || placeholder}
+        value={value ?? ''}
+        disabled={disabled}
+        onChange={(e) => onValueChange?.(e.target.value)}
+      >
+        <option value="" disabled hidden>
+          {placeholder}
+        </option>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    ),
+  };
+});
 
 import { useConfigStore } from '@/store';
 import { MessengerWelcomeSettings } from '../MessengerWelcomeSettings';
@@ -26,6 +71,10 @@ import { MessengerWelcomeSettings } from '../MessengerWelcomeSettings';
 beforeEach(() => {
   vi.clearAllMocks();
   mockBaseConfig = {};
+  mockCtas = {
+    volunteer: { label: 'Volunteer info', action: 'send_query' },
+    donate: { label: 'Donate', action: 'external_link' },
+  };
   (useConfigStore as unknown as { setState: typeof mockSetState }).setState = mockSetState;
 });
 
@@ -46,97 +95,122 @@ describe('MessengerWelcomeSettings', () => {
     expect(screen.getByText('Persistent menu')).toBeInTheDocument();
   });
 
-  it('shows the truthful-state notice (surfaces push to Meta on Deploy; edits alone do not)', () => {
+  it('CTA dropdown options come LIVE from cta_definitions (dynamic)', () => {
     render(<MessengerWelcomeSettings />);
-    // Title states the push happens on Deploy.
-    expect(screen.getByText(/push to Facebook & Instagram when you Deploy/)).toBeInTheDocument();
-    // Body is truthful that editing alone does not update Meta.
-    expect(screen.getByText(/Editing here without deploying does not update/)).toBeInTheDocument();
-    // Manual fallback still referenced.
-    expect(screen.getByText(/repush_welcome_surfaces\.py/)).toBeInTheDocument();
+    // Both configured CTAs render as options, labelled with their id.
+    expect(screen.getAllByRole('option', { name: /Volunteer info — volunteer/ }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('option', { name: /Donate — donate/ }).length).toBeGreaterThan(0);
   });
 
-  it('adding an ice breaker writes messenger_behavior.welcome.ice_breakers', async () => {
-    mockBaseConfig = { messenger_behavior: { welcome: {} } };
+  it('adding an ice breaker stores the exact PIC1:cta:{id} payload from the selected CTA', async () => {
     render(<MessengerWelcomeSettings />);
-
     await userEvent.type(screen.getByLabelText('Question'), 'How do I volunteer?');
-    await userEvent.type(screen.getByLabelText('Payload'), 'PIC1:VOLUNTEER_INFO');
+    await userEvent.selectOptions(screen.getByLabelText('Linked CTA'), 'PIC1:cta:volunteer');
     await userEvent.click(screen.getByRole('button', { name: /Add ice breaker/ }));
 
-    const state = applyLastUpdater({ messenger_behavior: { welcome: {} } });
-    const welcome = (state.config.baseConfig.messenger_behavior as Record<string, unknown>).welcome as {
-      ice_breakers?: Array<{ question: string; payload: string }>;
+    const state = applyLastUpdater({});
+    const mb = state.config.baseConfig.messenger_behavior as {
+      welcome?: { ice_breakers?: Array<{ question: string; payload: string }> };
     };
-    expect(welcome.ice_breakers).toEqual([
-      { question: 'How do I volunteer?', payload: 'PIC1:VOLUNTEER_INFO' },
+    expect(mb.welcome?.ice_breakers).toEqual([
+      { question: 'How do I volunteer?', payload: 'PIC1:cta:volunteer' },
     ]);
-    expect(state.config.isDirty).toBe(true);
   });
 
-  it('disables Add at the 4-item ice-breaker cap (capability map C5)', () => {
+  it('disables Add ice breaker at the ≤4 cap (Meta platform limit)', () => {
     mockBaseConfig = {
       messenger_behavior: {
         welcome: {
           ice_breakers: [
-            { question: 'Q1', payload: 'PIC1:A' },
-            { question: 'Q2', payload: 'PIC1:B' },
-            { question: 'Q3', payload: 'PIC1:C' },
-            { question: 'Q4', payload: 'PIC1:D' },
+            { question: 'Q1', payload: 'PIC1:cta:volunteer' },
+            { question: 'Q2', payload: 'PIC1:cta:donate' },
+            { question: 'Q3', payload: 'PIC1:cta:volunteer' },
+            { question: 'Q4', payload: 'PIC1:cta:donate' },
           ],
         },
       },
     };
     render(<MessengerWelcomeSettings />);
-
     expect(screen.getByRole('button', { name: /Add ice breaker/ })).toBeDisabled();
     expect(screen.getByText(/Maximum of 4 ice breakers reached/)).toBeInTheDocument();
-    expect(screen.getByText('4 / 4 ice breakers')).toBeInTheDocument();
   });
 
-  it('removing an ice breaker updates the array', async () => {
+  it('removing an ice breaker writes the filtered list', async () => {
     mockBaseConfig = {
-      messenger_behavior: { welcome: { ice_breakers: [{ question: 'Q1', payload: 'PIC1:A' }] } },
+      messenger_behavior: { welcome: { ice_breakers: [{ question: 'Q1', payload: 'PIC1:cta:volunteer' }] } },
     };
     render(<MessengerWelcomeSettings />);
-
     await userEvent.click(screen.getByRole('button', { name: 'Remove ice breaker 1' }));
 
     const state = applyLastUpdater({
-      messenger_behavior: { welcome: { ice_breakers: [{ question: 'Q1', payload: 'PIC1:A' }] } },
+      messenger_behavior: { welcome: { ice_breakers: [{ question: 'Q1', payload: 'PIC1:cta:volunteer' }] } },
     });
-    const welcome = (state.config.baseConfig.messenger_behavior as Record<string, unknown>).welcome as {
-      ice_breakers?: unknown[];
-    };
-    expect(welcome.ice_breakers).toEqual([]);
+    const mb = state.config.baseConfig.messenger_behavior as { welcome?: { ice_breakers?: unknown[] } };
+    expect(mb.welcome?.ice_breakers).toEqual([]);
   });
 
-  it('adding a persistent menu item writes messenger_behavior.welcome.persistent_menu', async () => {
-    mockBaseConfig = { messenger_behavior: { welcome: {} } };
+  it('adding a persistent-menu item links a CTA (PIC1:cta:{id})', async () => {
     render(<MessengerWelcomeSettings />);
-
     await userEvent.type(screen.getByLabelText('Title'), 'Our programs');
-    await userEvent.type(screen.getByLabelText('Payload (optional)'), 'PIC1:PROGRAMS');
+    await userEvent.selectOptions(screen.getByLabelText('Linked CTA (optional)'), 'PIC1:cta:donate');
     await userEvent.click(screen.getByRole('button', { name: /Add menu item/ }));
 
-    const state = applyLastUpdater({ messenger_behavior: { welcome: {} } });
-    const welcome = (state.config.baseConfig.messenger_behavior as Record<string, unknown>).welcome as {
-      persistent_menu?: Array<{ title: string; payload?: string }>;
+    const state = applyLastUpdater({});
+    const mb = state.config.baseConfig.messenger_behavior as {
+      welcome?: { persistent_menu?: Array<{ title: string; payload?: string }> };
     };
-    expect(welcome.persistent_menu).toEqual([{ title: 'Our programs', payload: 'PIC1:PROGRAMS' }]);
-    expect(state.config.isDirty).toBe(true);
+    expect(mb.welcome?.persistent_menu).toEqual([{ title: 'Our programs', payload: 'PIC1:cta:donate' }]);
   });
 
-  it('creates messenger_behavior.welcome lazily on a bare config (no crash)', async () => {
-    mockBaseConfig = {}; // no messenger_behavior, no welcome
+  it('a menu item can use a URL instead of a CTA', async () => {
     render(<MessengerWelcomeSettings />);
+    await userEvent.type(screen.getByLabelText('Title'), 'Website');
+    await userEvent.type(screen.getByLabelText('URL (optional)'), 'https://example.org');
+    await userEvent.click(screen.getByRole('button', { name: /Add menu item/ }));
 
+    const state = applyLastUpdater({});
+    const mb = state.config.baseConfig.messenger_behavior as {
+      welcome?: { persistent_menu?: Array<{ title: string; url?: string }> };
+    };
+    expect(mb.welcome?.persistent_menu).toEqual([{ title: 'Website', url: 'https://example.org' }]);
+  });
+
+  it('lazily creates messenger_behavior.welcome on a bare config (no crash)', async () => {
+    mockBaseConfig = {}; // no messenger_behavior
+    render(<MessengerWelcomeSettings />);
     await userEvent.type(screen.getByLabelText('Question'), 'Q');
-    await userEvent.type(screen.getByLabelText('Payload'), 'PIC1:X');
+    await userEvent.selectOptions(screen.getByLabelText('Linked CTA'), 'PIC1:cta:volunteer');
     await userEvent.click(screen.getByRole('button', { name: /Add ice breaker/ }));
 
     const state = applyLastUpdater({});
     const mb = state.config.baseConfig.messenger_behavior as { welcome?: { ice_breakers?: unknown[] } };
-    expect(mb?.welcome?.ice_breakers).toEqual([{ question: 'Q', payload: 'PIC1:X' }]);
+    expect(mb?.welcome?.ice_breakers).toEqual([{ question: 'Q', payload: 'PIC1:cta:volunteer' }]);
+  });
+
+  it('shows a hint and disables Add when no CTAs are defined yet', () => {
+    mockCtas = {};
+    render(<MessengerWelcomeSettings />);
+    expect(screen.getByText(/No CTAs defined yet/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add ice breaker/ })).toBeDisabled();
+  });
+
+  it('preserves a saved payload that no longer matches a CTA (does not silently blank it)', () => {
+    mockBaseConfig = {
+      messenger_behavior: {
+        welcome: { ice_breakers: [{ question: 'Old', payload: 'PIC1:cta:deleted_cta' }] },
+      },
+    };
+    render(<MessengerWelcomeSettings />);
+    // The stale payload survives as a distinctly-labelled option.
+    expect(
+      screen.getAllByRole('option', { name: /PIC1:cta:deleted_cta — not a current CTA/ }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows the truthful-state notice (surfaces push to Meta on Deploy; edits alone do not)', () => {
+    render(<MessengerWelcomeSettings />);
+    expect(screen.getByText(/push to Facebook & Instagram when you Deploy/)).toBeInTheDocument();
+    expect(screen.getByText(/Editing here without deploying does not update/)).toBeInTheDocument();
+    expect(screen.getByText(/repush_welcome_surfaces\.py/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What
The ice-breaker and persistent-menu **Payload** fields are now a **dropdown of your CTAs** instead of free text.

## Why
The payload has to be the exact `PIC1:cta:{id}` the Messenger processor resolves — free text was typo-prone, and the old placeholder (`PIC1:VOLUNTEER_INFO`) didn't even match the required format (it would silently fall through to a generic KB answer instead of firing the CTA). A dropdown removes the whole error class.

## How
- Options are built **live from `cta_definitions`** (`state.ctas.ctas`) — a reactive selector, so the list tracks CTAs as they're added/removed elsewhere in the builder.
- Selecting a CTA stores the exact `PIC1:cta:{id}` value. No typing.
- **Ice breaker:** required CTA dropdown. **Persistent menu:** optional CTA dropdown (`— No CTA —` sentinel) **or** a URL.
- A saved payload that no longer matches a CTA (deleted CTA / legacy raw value) is **preserved** as a "— not a current CTA" option rather than silently blanked.
- No CTAs yet → hint + disabled Add.

Copy updated (Payload → **Linked CTA**; "links to a CTA").

## Tests
The Radix `Select` is flaky in jsdom, so tests mock it to a native `<select>` (same value/onValueChange/options contract). Coverage: dynamic options reflect the store, exact `PIC1:cta:{id}` mapping on add, stale-payload preserve, empty-CTA state, URL alternative, ≤4 cap, lazy-init. **11 welcome tests + full suite 537/537** · typecheck + eslint clean · prod build ok.

> Visual/interaction verification of the actual Radix dropdown is operator-side (jsdom can't drive it reliably).

🤖 Generated with [Claude Code](https://claude.com/claude-code)