### PR TITLE
fix(cb): send operator Clerk token on welcome repush

### DIFF
--- a/src/lib/api/__tests__/metaWelcome.test.ts
+++ b/src/lib/api/__tests__/metaWelcome.test.ts
@@ -83,6 +83,22 @@ describe('repushWelcomeSurfaces', () => {
     );
   });
 
+  it('sends the operator Authorization header when provided', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ result: { skipped: 'x' } }) });
+    await repushWelcomeSurfaces('TENANT_1', 'Bearer op-token');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/meta/channels/TENANT_1/repush-welcome'),
+      expect.objectContaining({ method: 'POST', headers: { Authorization: 'Bearer op-token' } })
+    );
+  });
+
+  it('omits the Authorization header when no token is passed', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ result: { skipped: 'x' } }) });
+    await repushWelcomeSurfaces('TENANT_1');
+    const init = mockFetch.mock.calls[0][1];
+    expect(init.headers).toEqual({});
+  });
+
   it('passes through a best-effort skip (flag off / nothing to push)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/src/lib/api/metaWelcome.ts
+++ b/src/lib/api/metaWelcome.ts
@@ -11,8 +11,11 @@
  * Best-effort: the deploy itself is the primary action and has already
  * succeeded by the time this runs — a push failure only warns, never throws.
  *
- * The endpoint is unauthenticated today (CORS *, no Clerk), so no token is
- * sent. If it is ever put behind auth, thread the Clerk token through here.
+ * The /meta/channels/* routes now authorize the caller (lambda#463): they
+ * accept the operator's Clerk 'picasso-config' JWT (the same token the config
+ * API client sends). Callers pass that Authorization header in. The server-side
+ * backstop (Config Manager) covers the push independently, so a missing token
+ * here degrades to a warning, not a broken push.
  */
 import type { TenantConfig } from '@/types/config';
 
@@ -40,12 +43,15 @@ export type RepushOutcome =
  * - `failed`  — the call errored (network, 4xx/5xx); the caller should warn, not block
  * - `not-configured` — VITE_CHANNELS_API_URL is unset for this build (no auto-push wired)
  */
-export async function repushWelcomeSurfaces(tenantId: string): Promise<RepushOutcome> {
+export async function repushWelcomeSurfaces(
+  tenantId: string,
+  authorization?: string,
+): Promise<RepushOutcome> {
   if (!CHANNELS_API_URL) return { status: 'not-configured' };
   try {
     const res = await fetch(
       `${CHANNELS_API_URL}/meta/channels/${encodeURIComponent(tenantId)}/repush-welcome`,
-      { method: 'POST' }
+      { method: 'POST', headers: authorization ? { Authorization: authorization } : {} }
     );
     const body = (await res.json().catch(() => ({}))) as {
       error?: string;

--- a/src/store/slices/config.ts
+++ b/src/store/slices/config.ts
@@ -6,6 +6,7 @@
 import type { TenantConfig, ConversationalForm, ConversationBranch } from '@/types/config';
 import type { SliceCreator, ConfigSlice } from '../types';
 import * as configAPI from '@/lib/api/config-operations';
+import { configApiClient } from '@/lib/api/client';
 import { ConfigAPIError } from '@/lib/api/errors';
 import { shouldRepushWelcome, repushWelcomeSurfaces } from '@/lib/api/metaWelcome';
 
@@ -241,7 +242,10 @@ export const createConfigSlice: SliceCreator<ConfigSlice> = (set, get) => ({
       // so an operator never has to run the M5 re-push script by hand. Best-effort:
       // the deploy already succeeded, so a push failure only warns.
       if (shouldRepushWelcome(mergedConfig)) {
-        const outcome = await repushWelcomeSurfaces(state.config.tenantId);
+        // Same operator Clerk token the config API client sends; the /meta/
+        // channels/* routes now require it (lambda#463).
+        const authHeaders = await configApiClient.getAuthHeaders();
+        const outcome = await repushWelcomeSurfaces(state.config.tenantId, authHeaders.Authorization);
         if (outcome.status === 'pushed') {
           state.ui.addToast({
             type: 'success',


### PR DESCRIPTION
Config Builder half of the `Meta_OAuth_Handler` caller-authz fix (lambda#463).

The post-deploy welcome-surface repush (`POST /meta/channels/{id}/repush-welcome`) was sent with no auth. Now that the route authorizes the caller, thread the operator's Clerk `picasso-config` token — the same one the config API client already sends (`configApiClient.getAuthHeaders()`) — so it passes the operator auth path instead of 401'ing.

The server-side backstop (Config Manager → Meta_OAuth_Handler, exempt as an IAM invoke) covers the push independently, so a missing token only degrades to a warning, never a broken push.

- `metaWelcome` tests 11/11 (added: sends `Authorization` when provided; omits when absent).
- `tsc --noEmit` clean; store tests 25/25.

Part of the 4-PR change: infra grant (picasso#784) → portal (dashboard#74) → **this** → lambda enforcement (merges last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)