### PR TITLE
feat(create-tenant): Generate button for tenant IDs

### DIFF
--- a/src/components/modals/CreateTenantModal.tsx
+++ b/src/components/modals/CreateTenantModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Copy, Check, Loader2, Plus } from 'lucide-react';
+import { Copy, Check, Loader2, Plus, Sparkles } from 'lucide-react';
 import {
   Modal,
   ModalContent,
@@ -27,6 +27,22 @@ interface CreateTenantModalProps {
 }
 
 type ViewState = 'form' | 'loading' | 'success';
+
+/**
+ * Generate a tenant ID matching the platform convention: a 3-letter uppercase
+ * prefix derived from the organization name + 6 random digits
+ * (e.g. MyRecruiter → MYR384719, Austin Angels → AUS123957).
+ * Missing prefix letters (short/empty org name) are padded with random A-Z.
+ */
+function generateTenantId(orgName: string): string {
+  const letters = (orgName.match(/[a-zA-Z]/g) || []).join('').toUpperCase();
+  let prefix = letters.slice(0, 3);
+  while (prefix.length < 3) {
+    prefix += String.fromCharCode(65 + Math.floor(Math.random() * 26));
+  }
+  const digits = String(Math.floor(Math.random() * 1_000_000)).padStart(6, '0');
+  return `${prefix}${digits}`;
+}
 
 interface CreateTenantResponse {
   success: boolean;
@@ -67,6 +83,14 @@ export const CreateTenantModal: React.FC<CreateTenantModalProps> = ({ open, onCl
 
   const primaryColor = useWatch({ control, name: 'primary_color' });
   const subscriptionTier = useWatch({ control, name: 'subscription_tier' });
+  const orgName = useWatch({ control, name: 'org_name' });
+
+  const handleGenerateTenantId = () => {
+    setValue('tenant_id', generateTenantId(orgName), {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+  };
 
   const handleClose = () => {
     reset();
@@ -154,14 +178,33 @@ export const CreateTenantModal: React.FC<CreateTenantModalProps> = ({ open, onCl
               {...register('org_name')}
             />
 
-            <Input
-              label="Tenant ID"
-              placeholder="my-company"
-              required
-              helperText="Unique identifier (alphanumeric, hyphens, underscores)"
-              error={errors.tenant_id?.message}
-              {...register('tenant_id')}
-            />
+            <div>
+              <label
+                htmlFor="tenant_id"
+                className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Tenant ID <span className="text-red-500">*</span>
+              </label>
+              <div className="flex items-start gap-2">
+                <Input
+                  id="tenant_id"
+                  placeholder="MYR384719"
+                  className="flex-1"
+                  helperText="3-letter org prefix + 6 digits (alphanumeric, hyphens, underscores)"
+                  error={errors.tenant_id?.message}
+                  {...register('tenant_id')}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleGenerateTenantId}
+                  className="shrink-0"
+                >
+                  <Sparkles className="w-4 h-4 mr-2" />
+                  Generate
+                </Button>
+              </div>
+            </div>
 
             <Input
               label="Chat Title"

--- a/src/components/modals/__tests__/CreateTenantModal.test.tsx
+++ b/src/components/modals/__tests__/CreateTenantModal.test.tsx
@@ -22,6 +22,28 @@ describe('CreateTenantModal', () => {
     expect(screen.getByLabelText(/knowledge base id/i)).toBeInTheDocument();
   });
 
+  it('generates a tenant_id from the org name (3-letter prefix + 6 digits)', async () => {
+    const user = userEvent.setup();
+    render(<CreateTenantModal open={true} onClose={vi.fn()} />);
+
+    await user.type(screen.getByLabelText(/organization name/i), 'MyRecruiter');
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+
+    const tenantIdInput = screen.getByLabelText(/tenant id/i) as HTMLInputElement;
+    expect(tenantIdInput.value).toMatch(/^MYR\d{6}$/);
+  });
+
+  it('generates a valid tenant_id even when the org name is empty', async () => {
+    const user = userEvent.setup();
+    render(<CreateTenantModal open={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+
+    const tenantIdInput = screen.getByLabelText(/tenant id/i) as HTMLInputElement;
+    // Falls back to random uppercase letters; still 3 letters + 6 digits.
+    expect(tenantIdInput.value).toMatch(/^[A-Z]{3}\d{6}$/);
+  });
+
   it('validates tenant_id format', async () => {
     const user = userEvent.setup();
     render(<CreateTenantModal open={true} onClose={vi.fn()} />);


### PR DESCRIPTION
## What
Adds a **Generate** button to the Create Tenant modal's Tenant ID field.

## Why
The tenant ID field was free-text and hand-typed. There is no server-side ID generator — `Picasso_Config_Manager` (`POST /config`) only *validates* the operator-supplied `tenant_id` and derives the hash. Every real tenant ID follows one convention: **3-letter uppercase org prefix + 6 digits** (`MYR384719`, `AUS123957`, `FOS402334`). This button replicates that convention so operators stop guessing.

## How
- `generateTenantId(orgName)`: first 3 letters of the Organization Name (uppercased), padded with random A–Z if the org name is too short/empty, + 6 random digits.
- Button reads the Organization Name field already on the modal and populates Tenant ID via `setValue(..., { shouldValidate: true, shouldDirty: true })`.
- Output always matches the schema regex `^[A-Za-z0-9_-]+$`.

## Notes
- IDs are random (not sequential); the backend already rejects duplicates with "Tenant already exists", so a collision just means clicking Generate again. Kept simple — no client-side uniqueness check.

## Tests
- Full `CreateTenantModal` suite: **8 passed** (2 new — org-derived prefix + empty-org fallback).
- typecheck ✅ · lint ✅ · production build ✅ (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)