### PR TITLE
ci(pr-checks): gate PRs to staging (mirror picasso staging model)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - staging   # code PRs route to staging first — gate them too (was main-only)
 
 env:
   NODE_VERSION: '22'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,9 +537,13 @@ aws s3 ls s3://myrecruiter-picasso/
 
 ### Frontend Deployment
 
-Deployment is CI-driven (there is no local deploy script):
+Deployment is CI-driven (there is no local deploy script). Branching mirrors
+the picasso repo: `staging` is a protected long-lived integration branch
+(force-push + deletion disabled) and `main` is prod. Code PRs route to
+`staging` first (soak), then promote `staging → main`.
 
-- **Staging (525):** `pr-checks.yml` deploys a preview on every PR →
+- **Staging (525):** `pr-checks.yml` runs the quality gates + deploys a preview
+  on every PR to **`main` or `staging`** →
   `picasso-config-builder-staging` / `staging.config.myrecruiter.ai`.
 - **Production (614):** `deploy-production.yml` is dispatch-only and double-gated
   (human approval + blocking prod-config schema validation) →


### PR DESCRIPTION
## What
Adds `staging` to `pr-checks.yml`'s `pull_request` base branches (was `main`-only).

## Why
We created a protected long-lived `staging` branch to mirror the picasso repo's staging-first flow. For that branch to be functional, PRs targeting it must run the same quality gates + staging-preview deploy. GitHub reads the `pull_request` trigger from the **base** branch, so `staging` must appear in the trigger list for feature→staging PRs to run CI.

## Change
- `.github/workflows/pr-checks.yml`: `branches: [main]` → `[main, staging]` (one line, mirrors picasso's exact edit + comment).
- `CLAUDE.md`: document the `staging` integration branch and staging-first routing in the Frontend Deployment section.

## Safety
- **Not** a `pull_request_target` trigger — the `workflow-trigger-guard` (T-02) job still passes (verified locally by simulating the guard's grep).
- No application code touched; no behavior change to prod (`deploy-production.yml` stays dispatch-only, gated).

## Bootstrap note
Landing on `main` first (main already triggers pr-checks, so this PR is fully gated). Immediately after merge, `staging` is fast-forwarded to `main` so both branches carry the trigger with **zero drift** — after that, feature→`staging` PRs run CI.

## Follow-on flow (now enabled)
feature branch → PR to `staging` (gates + preview soak) → promote-PR `staging → main` (gates) → dispatch `deploy-production.yml` (gated prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)